### PR TITLE
Fix Release workflow on main; spec onboarding (init / doctor / upgrade) and qf open

### DIFF
--- a/.github/scripts/check_release.py
+++ b/.github/scripts/check_release.py
@@ -8,6 +8,12 @@ the version declared in ``__about__.py`` is not yet on the index".
 Writes ``version``, ``target`` and ``publish`` as ``KEY=value`` lines on stdout,
 which the workflow appends to ``$GITHUB_OUTPUT``.
 
+stdout is therefore a machine interface: it carries ONLY ``key=value`` lines.
+Every human-facing message goes to stderr. ``$GITHUB_OUTPUT`` rejects any line
+that is not ``key=value``, so a stray informational print on stdout fails the
+whole job -- which is exactly what happened on the first push to ``main``.
+``tests/test_release_script.py`` enforces the contract.
+
 Run locally to see what the next push to main would do::
 
     python .github/scripts/check_release.py
@@ -36,6 +42,16 @@ INDEXES = {
 
 # PEP 440, restricted to the subset this project actually uses.
 VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.dev\d+)?$")
+
+
+def note(message: str) -> None:
+    """Human-facing progress line. stderr, never stdout -- stdout is $GITHUB_OUTPUT."""
+    print(message, file=sys.stderr)
+
+
+def emit(key: str, value: str) -> None:
+    """The only writer to stdout: one ``key=value`` line for $GITHUB_OUTPUT."""
+    print(f"{key}={value}")
 
 
 def fail(message: str) -> None:
@@ -86,10 +102,11 @@ def main() -> None:
     # runs (workflow_dispatch) are always allowed -- that is how you rehearse.
     enabled = os.environ.get("RELEASE_ENABLED", "").strip().lower() == "true"
     if target == "pypi" and not enabled:
-        print("Releases to PyPI are not armed (repository variable RELEASE_ENABLED != 'true').")
-        print("See docs/RELEASING.md for the one-time Trusted Publishing setup.")
-        for key, value in (("version", read_version()), ("target", target), ("publish", "false")):
-            print(f"{key}={value}")
+        note("Releases to PyPI are not armed (repository variable RELEASE_ENABLED != 'true').")
+        note("See docs/RELEASING.md for the one-time Trusted Publishing setup.")
+        emit("version", read_version())
+        emit("target", target)
+        emit("publish", "false")
         return
 
     version = read_version()
@@ -103,13 +120,13 @@ def main() -> None:
     existing = released_versions(dist_name, target)
 
     if existing is None:
-        print(f"{dist_name} is not on {target} yet -- this would be the first release.")
+        note(f"{dist_name} is not on {target} yet -- this would be the first release.")
         publish = True
     elif version in existing:
-        print(f"{dist_name} {version} is already on {target}; nothing to publish.")
+        note(f"{dist_name} {version} is already on {target}; nothing to publish.")
         publish = False
     else:
-        print(f"{dist_name} {version} is not on {target}; it will be published.")
+        note(f"{dist_name} {version} is not on {target}; it will be published.")
         publish = True
 
     # Release discipline: a version that ships must be described. Checked only
@@ -122,12 +139,9 @@ def main() -> None:
                 f"Add a '## [{version}]' heading describing the release."
             )
 
-    for key, value in (
-        ("version", version),
-        ("target", target),
-        ("publish", str(publish).lower()),
-    ):
-        print(f"{key}={value}")
+    emit("version", version)
+    emit("target", target)
+    emit("publish", str(publish).lower())
 
 
 if __name__ == "__main__":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,14 @@ the same declaration, and a parity test fails the build if one is missing.
 Cross-field rules (weights match tickers, `--portfolio` excludes `--tickers`)
 are model validators, never handler code.
 
+**Never read `os.environ` for a setting.** Declare it in `settings.py` — env
+var, secret flag, how to obtain it, optional live validator — and `qf init`,
+`qf doctor`, `qf config`, and the 0004 settings page derive from that. A test
+fails the build on an undeclared env var. **When you add a provider, a setting,
+or a runtime dependency, register a doctor `Check` in the same change**; a
+test asserts every setting and provider has one. Every failing doctor line
+carries its fix.
+
 **Tests are organized by what they prove** — `tests/core/` (known answers),
 `tests/data/` (recorded fixtures, conformance), `tests/cli/`,
 `tests/architecture/` (import and literal rules), `tests/invariants/` (every

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the milestone plans in [`openspec/changes/`](openspec/changes/).
 | # | Milestone | Ships | State |
 |---|---|---|---|
 | [0000](openspec/changes/0000-release-engineering/) | Release engineering | CI gate, version-gated PyPI publishing | ✅ Done |
-| [0001](openspec/changes/0001-foundation-data-and-cli/) | Foundation | Command registry, storage port, providers, currency, observability, `qf data` | 📋 Planned |
+| [0001](openspec/changes/0001-foundation-data-and-cli/) | Foundation | `init`/`doctor` onboarding, command registry, storage port, providers, currency, observability, `qf data` | 📋 Planned |
 | [0002](openspec/changes/0002-portfolio-optimization/) | **Portfolio optimization (v1)** | Returns, risk, Markowitz, frontier, backtest | 📋 Planned |
 | [0003](openspec/changes/0003-local-persistence/) | Local persistence | Saved portfolios, goals, run history, `qf db` | 📋 Planned |
 | [0004](openspec/changes/0004-web-ui/) | Web UI | FastAPI + React SPA derived from the registry, `qf serve` | 📋 Planned |
@@ -75,7 +75,13 @@ docker run -p 8787:8787 -v quantfolio:/data espin086/quantfolio serve --host 0.0
 
 ```bash
 pip install quantfolio-cli          # (once the first release is published)
+qf init                             # guided setup: keys, storage — ends by running doctor
+qf doctor                           # every check tells you what's wrong and how to fix it
 ```
+
+That's the whole onboarding path, and it stays three commands as the tool grows.
+`qf doctor --fix` applies the safe repairs; `qf upgrade` detects how you
+installed and runs the matching upgrade.
 
 Or for development:
 
@@ -93,7 +99,7 @@ pre-commit install                  # optional: run CI's checks before each comm
 **No API key is required** for the core tool. Prices come from yfinance and factor
 returns from the Ken French Data Library, both keyless. A free
 [FRED key](https://fred.stlouisfed.org/docs/api/api_key.html) unlocks macro series
-and the live risk-free rate:
+and the live risk-free rate — `qf init` asks for it and offers to verify it, or:
 
 ```bash
 qf config set fred_api_key <YOUR_KEY>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the milestone plans in [`openspec/changes/`](openspec/changes/).
 | [0001](openspec/changes/0001-foundation-data-and-cli/) | Foundation | `init`/`doctor` onboarding, command registry, storage port, providers, currency, observability, `qf data` | 📋 Planned |
 | [0002](openspec/changes/0002-portfolio-optimization/) | **Portfolio optimization (v1)** | Returns, risk, Markowitz, frontier, backtest | 📋 Planned |
 | [0003](openspec/changes/0003-local-persistence/) | Local persistence | Saved portfolios, goals, run history, `qf db` | 📋 Planned |
-| [0004](openspec/changes/0004-web-ui/) | Web UI | FastAPI + React SPA derived from the registry, `qf serve` | 📋 Planned |
+| [0004](openspec/changes/0004-web-ui/) | Web UI | FastAPI + React SPA derived from the registry, `qf serve`, `qf open` | 📋 Planned |
 | [0005](openspec/changes/0005-docker-distribution/) | Docker | One image on Docker Hub, `qf deploy` | 📋 Planned |
 | [0006](openspec/changes/0006-landing-page/) | Landing page | Animated dark GitHub Pages site | 📋 Planned |
 | [0007](openspec/changes/0007-equity-factor-analysis/) | Factor analysis | CAPM, Fama-French 3/5 + momentum | 📋 Planned |
@@ -81,7 +81,8 @@ qf doctor                           # every check tells you what's wrong and how
 
 That's the whole onboarding path, and it stays three commands as the tool grows.
 `qf doctor --fix` applies the safe repairs; `qf upgrade` detects how you
-installed and runs the matching upgrade.
+installed and runs the matching upgrade. Once the web UI lands, `qf open` starts
+it and puts it in your browser — `qf open doctor` goes straight to a view.
 
 Or for development:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ far ahead goes stale before it is used.
 | 0001 | Foundation: onboarding, registry, storage port, data layer + quality, currency, observability, testing | 0000 | ~67h | proposal + 8 specs + design + tasks |
 | 0002 | **Portfolio optimization → v1.0.0** | 0001 | ~48h | proposal + spec + design + tasks |
 | 0003 | Local persistence (SQLite) → v1.1 | 0002 | ~25h est. | proposal + spec |
-| 0004 | Web UI (FastAPI + React) → v1.2 | 0003 | ~70h est. | proposal + 2 specs + design |
+| 0004 | Web UI (FastAPI + React) → v1.2 | 0003 | ~72h est. | proposal + 2 specs + design |
 | 0005 | Docker distribution → v1.2 | 0004 | ~25h est. | proposal + spec |
 | 0006 | Landing page (GitHub Pages) → v1.2 | 0005 | ~30h est. | proposal + spec |
 | 0007 | Equity & factor analysis → v1.3 | 0002 | ~35h est. | proposal + spec |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ far ahead goes stale before it is used.
 | # | Milestone | Depends on | Est. | Planning depth |
 |---|---|---|---|---|
 | 0000 | Release engineering: CI gate + PyPI pipeline | — | done | proposal + spec + tasks |
-| 0001 | Foundation: registry, storage port, data layer + quality, currency, observability, testing | 0000 | ~58h | proposal + 7 specs + design + tasks |
+| 0001 | Foundation: onboarding, registry, storage port, data layer + quality, currency, observability, testing | 0000 | ~67h | proposal + 8 specs + design + tasks |
 | 0002 | **Portfolio optimization → v1.0.0** | 0001 | ~48h | proposal + spec + design + tasks |
 | 0003 | Local persistence (SQLite) → v1.1 | 0002 | ~25h est. | proposal + spec |
 | 0004 | Web UI (FastAPI + React) → v1.2 | 0003 | ~70h est. | proposal + 2 specs + design |
@@ -22,7 +22,7 @@ far ahead goes stale before it is used.
 | 0009 | Econometrics & forecasting → v1.5 | 0007 | ~40h est. | proposal + spec |
 | 0010 | Exchange rates & PPP → v1.6 | 0002, 0008 | ~35h est. | proposal + 2 specs |
 
-**v1.0.0 = 0001 + 0002 (~106h).** **v1.2, the deployable product = 0003–0006
+**v1.0.0 = 0001 + 0002 (~115h).** **v1.2, the deployable product = 0003–0006
 (~150h more).**
 
 ## Sequencing rationale

--- a/openspec/changes/0001-foundation-data-and-cli/design.md
+++ b/openspec/changes/0001-foundation-data-and-cli/design.md
@@ -51,6 +51,47 @@ model as a validator, so it is written once and cannot drift between commands.
 And results are typed, carrying their own provenance, so one renderer handles
 every command and no command formats its own output.
 
+## Onboarding: settings and checks are registries
+
+The user's path is `pip install` → `qf init` → `qf doctor`, and the design
+problem is keeping it that short as ten milestones add keys, providers, and
+runtime dependencies. The answer is the same one the command registry gives:
+declare once, derive everywhere.
+
+```python
+@setting
+class FredApiKey:
+    key = "fred_api_key"
+    env = "FRED_API_KEY"
+    secret = True
+    required = False
+    description = "Unlocks FRED macro series and the live risk-free rate."
+    obtain = "https://fred.stlouisfed.org/docs/api/api_key.html"
+    def validate_live(self, value: str) -> CheckResult: ...   # one cheap request
+```
+
+From that one declaration: `qf init` prompts (no echo, masked on re-run, live
+verification offered), `qf doctor` checks presence and validity, `qf config
+set|show` accepts it, and 0004 renders a settings field. A milestone that adds
+a key adds a declaration, and gets all four for free — and a test asserts that
+every environment variable the code reads is a declared setting, so the
+shortcut of reading `os.environ` directly fails the build.
+
+Doctor is the same shape: a `Check` registry with `run` and an optional
+idempotent `fix`. 0003 registers the migration check, 0004 the server checks,
+0010 the FX provider check. Every line doctor prints carries its next step, on
+the principle that a diagnostic without a fix is a complaint. `qf deploy check`
+and the container `HEALTHCHECK` (0005) call doctor rather than re-implementing
+health, so there is one definition of "this install works".
+
+`qf init` ends by running doctor and printing one runnable first command
+tailored to what was configured — the last step of onboarding is the first step
+of use.
+
+"GUI" here means a guided terminal wizard built on Rich prompts. 0004's
+settings page is the browser form of the same registry; a `qf init --web` that
+opens it is a natural addition there, not here.
+
 ## Storage: a port, not a database
 
 Two protocols and a registry:
@@ -311,6 +352,9 @@ must never need a `grep -v`.
 | Instrument adapters | Instrument `core/` | Preserves purity, and adapter-observed timings are what a trace reader wants |
 | OTel API with optional SDK | Always-on tracing, or none | Zero dependency and zero overhead by default, same call sites either way |
 | structlog | stdlib `logging` alone | Typed key/value context and bound scopes; still routes third-party stdlib records through one handler |
+| Settings and checks as registries | Prompts and checks hand-written per key | A milestone that adds a key must add init, doctor, config, and UI handling; a registry makes forgetting one a build failure |
+| Doctor exits 1 only on failures; warnings need `--strict` | Warnings fail | A warning-fails default trains users to ignore doctor |
+| Network checks capped at 5s with `--offline` | Uncapped | A diagnostic that hangs is worse than none |
 | Registry in 0001 | Registry in 0004 when the API needs it | Adding consumers to declarations is a generator each; retrofitting declarations onto hand-written commands is a rewrite of every one |
 | pydantic parameter models | Typer-native annotations | One validation path serves CLI, API, and UI; cross-field rules live in one validator |
 | `CurrencyPair` type carrying direction | A string like `"EURUSD"` plus a convention | Conventions are remembered wrongly; a type is checked |

--- a/openspec/changes/0001-foundation-data-and-cli/proposal.md
+++ b/openspec/changes/0001-foundation-data-and-cli/proposal.md
@@ -12,9 +12,10 @@ status: proposed
 Someone with a fresh `pip install quantfolio` and **no API keys** can run:
 
 ```bash
+pip install quantfolio-cli
+qf init          # configure keys and storage, interactively; ends by running doctor
+qf doctor        # every check actionable; exit 0 means it works
 qf data prices AAPL MSFT NVDA --start 2015-01-01 --format table
-qf data factors --model ff5 --start 2015-01-01
-qf cache info
 ```
 
 …and get clean tabular output, cached locally, with the second run served from
@@ -44,6 +45,11 @@ the codebase is small enough that the rule is free to follow.
 - **New capability `observability`** — structured logging on by default and
   OpenTelemetry tracing behind an optional extra, instrumenting the adapters and
   the I/O layer while `core/` stays pure.
+- **New capability `onboarding`** — `qf init`, `qf doctor`, `qf upgrade`, and a
+  settings registry they all derive from. Every configurable value is declared
+  once; init prompts for it, doctor checks it, `qf config` accepts it, and the
+  0004 settings page renders it. Doctor's checks are a registry too, and a test
+  asserts every setting and provider has one.
 - **New capability `command-registry`** — every command declared once with a
   pydantic parameter model and a typed result; the Typer CLI is generated from
   it. 0004 later derives the HTTP API and UI forms from the same declarations,
@@ -100,6 +106,9 @@ the codebase is small enough that the rule is free to follow.
 | Instrumentation changes behavior or output | A test asserts stdout is byte-identical across log levels and with tracing on and off |
 | A rate is applied in the wrong direction | Direction is carried by `CurrencyPair(base, quote)`, call sites never touch a raw rate, and round-trip conversion is a test |
 | A listing quoted in a sub-unit (GBp, ZAc) is read as the major unit | The data layer normalizes to the major unit and a test covers a real pence-quoted listing — a silent hundred-fold error otherwise |
+| A later milestone adds an API key or provider and forgets to make it configurable or diagnosable | Settings and checks are registries; a test asserts every env var the code reads is a declared setting and every setting and provider has a doctor check |
+| `qf init` hangs a container or CI on a prompt | `--non-interactive` takes values from flags and environment only and exits 3 naming any missing required value |
+| Doctor hangs on a dead network | Every network check has a five-second cap and `--offline` skips them; skipped is not failed |
 | Hand-written commands in 0001 have to be rewritten when 0004 needs API and UI surfaces | The registry lands here; 0004 adds consumers of existing declarations rather than restructuring them |
 | "A test SHALL assert" in later specs never becomes a test | The `testing` spec defines the suites and a scenario-coverage test that fails on an unreferenced scenario once a change is marked implemented |
 | Bad provider rows produce plausible-looking wrong results | Validation on ingest; implausible moves flagged in `attrs` and surfaced beside results; missing-data handling requires an explicit policy |

--- a/openspec/changes/0001-foundation-data-and-cli/specs/onboarding/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/onboarding/spec.md
@@ -1,0 +1,177 @@
+# onboarding — spec delta (0001)
+
+The user's path is three commands, and each later milestone has to keep it
+three:
+
+```
+pip install quantfolio-cli
+qf init        # configure everything configurable, interactively
+qf doctor      # prove the install works, or say exactly what is wrong
+```
+
+## ADDED Requirements
+
+### Requirement: Settings are declared once
+
+Every configurable value SHALL be one declaration in `quantfolio/settings.py`,
+the way every command is one declaration in the registry.
+
+#### Scenario: Declaration shape
+- **WHEN** a setting is declared
+- **THEN** it SHALL carry a key, an environment variable name, a type, a
+  default or `required`, whether it is a secret, a one-line description, a URL
+  or instruction for obtaining it where applicable, and an optional live
+  validator
+
+#### Scenario: Four consumers, one source
+- **WHEN** a setting exists in the registry
+- **THEN** `qf init` SHALL prompt for it, `qf doctor` SHALL check it,
+  `qf config set|show` SHALL accept it, and the 0004 settings page SHALL render
+  it, with no per-surface code
+
+#### Scenario: A milestone cannot add an unconfigurable key
+- **WHEN** the test suite runs
+- **THEN** a test SHALL assert that every environment variable the code reads
+  corresponds to a declared setting
+- **AND** SHALL assert that every declared setting has a doctor check
+
+### Requirement: `qf init`
+
+#### Scenario: Guided, in the terminal
+- **WHEN** `qf init` runs in a TTY
+- **THEN** it SHALL walk the settings registry in order, showing each setting's
+  description and where to obtain it, and prompt for a value
+- **AND** secrets SHALL be entered without echo
+
+#### Scenario: Idempotent and re-runnable
+- **WHEN** `qf init` runs against an existing configuration
+- **THEN** it SHALL show each current value — secrets masked to their last four
+  characters — and offer to keep or replace it
+- **AND** re-running with no changes SHALL leave the configuration byte-identical
+
+#### Scenario: Optional settings can be skipped
+- **WHEN** a setting is not required
+- **THEN** the prompt SHALL accept an empty answer and state what will not work
+  without it, naming the commands affected
+
+#### Scenario: Live validation with consent
+- **WHEN** a setting declares a live validator and the user provides a value
+- **THEN** `qf init` SHALL offer to verify it with one request, and report the
+  result
+- **AND** a failed verification SHALL let the user retry, keep the value anyway,
+  or skip — never silently store a key that just failed
+
+#### Scenario: Storage is set up
+- **WHEN** `qf init` completes
+- **THEN** the database SHALL exist at the resolved URL with migrations applied,
+  and the config file SHALL be written at mode `0600`
+- **AND** the paths of both SHALL be printed
+
+#### Scenario: Non-interactive mode
+- **WHEN** `qf init --non-interactive` runs
+- **THEN** values SHALL be taken from flags and environment only, with no prompt
+- **AND** a missing required value SHALL exit 3 naming it, so scripts and
+  containers fail clearly rather than hang on a prompt
+
+#### Scenario: Ends with proof
+- **WHEN** `qf init` completes
+- **THEN** it SHALL run `qf doctor` and print the result
+- **AND** SHALL print one runnable first command tailored to what was
+  configured, so the next step is a copy-paste rather than a search
+
+#### Scenario: First-run hint
+- **WHEN** any command runs and no configuration exists
+- **THEN** stderr SHALL carry a one-line hint to run `qf init`
+- **AND** the command SHALL still proceed if it needs nothing that is missing —
+  the hint is a hint, not an error
+
+### Requirement: `qf doctor`
+
+#### Scenario: Checks are declared, like commands and settings
+- **WHEN** a diagnostic exists
+- **THEN** it SHALL be a registered `Check` with a name, a category, a `run`
+  returning ok / warn / fail with a message, and an optional idempotent `fix`
+- **AND** a milestone that adds a provider, a setting, or a runtime dependency
+  SHALL register a check for it in the same change
+
+#### Scenario: What is checked in 0001
+- **WHEN** `qf doctor` runs
+- **THEN** it SHALL check at least: Python version; installed quantfolio version
+  and whether a newer release exists; the installer in use; config file presence,
+  parseability, and `0600` permissions; every declared setting; database URL
+  resolution, reachability, writability, and schema version against the code;
+  cache size and staleness; each provider's reachability; which extras are
+  installed; and free disk space at the database path
+
+#### Scenario: Every line is actionable
+- **WHEN** a check does not pass
+- **THEN** its line SHALL state what is wrong and the exact command or action
+  that fixes it
+- **AND** a check SHALL never report a failure without a next step
+
+#### Scenario: Output
+- **WHEN** `qf doctor` runs in a TTY
+- **THEN** it SHALL render one line per check with a status glyph, grouped by
+  category, and a one-line summary
+- **AND** `--format json` SHALL emit the full structured result for scripting
+
+#### Scenario: Exit code
+- **WHEN** `qf doctor` completes
+- **THEN** it SHALL exit 0 if no check failed, and 1 if any did
+- **AND** warnings SHALL not affect the exit code unless `--strict` is given
+
+#### Scenario: Offline
+- **WHEN** `--offline` is given, or the network is unreachable
+- **THEN** network-dependent checks SHALL report as skipped, not failed
+- **AND** every network check SHALL have a timeout of at most five seconds, so
+  doctor never hangs
+
+#### Scenario: Safe automatic repair
+- **WHEN** `qf doctor --fix` runs
+- **THEN** every registered fix SHALL be attempted — creating the config
+  directory, correcting file permissions, applying pending migrations, clearing a
+  corrupt cache entry — and each SHALL be reported as applied or not applicable
+- **AND** no fix SHALL create, change, or delete a secret; those go through
+  `qf init` or `qf config set`
+
+#### Scenario: Secrets never appear
+- **WHEN** `qf doctor` reports on a secret setting
+- **THEN** it SHALL show presence and validity only, never the value, in any
+  output format
+
+#### Scenario: One implementation of health
+- **WHEN** 0005's `qf deploy check` or the container `HEALTHCHECK` needs to
+  assess the install
+- **THEN** it SHALL run doctor's checks rather than its own
+
+### Requirement: `qf upgrade`
+
+#### Scenario: Installer is detected, not assumed
+- **WHEN** `qf upgrade` runs
+- **THEN** it SHALL detect whether quantfolio was installed by pip, pipx, uv, or
+  is running in the container, and SHALL print the exact upgrade command for
+  that installer
+
+#### Scenario: Confirmation before acting
+- **WHEN** an upgrade command is about to run
+- **THEN** the user SHALL be asked to confirm, and `--yes` SHALL skip the prompt
+- **AND** `--check` SHALL only report whether a newer version exists
+
+#### Scenario: Post-upgrade migration
+- **WHEN** an upgrade completes
+- **THEN** the next `qf` invocation SHALL apply any pending migrations per 0003,
+  after the automatic backup that spec requires
+
+### Requirement: Onboarding is tested end to end
+
+#### Scenario: The three-command path is a test
+- **WHEN** CI's build job runs
+- **THEN** it SHALL install the built wheel into a clean environment, run
+  `qf init --non-interactive`, run `qf doctor --offline`, and assert exit 0
+- **AND** it SHALL then run one data command against a recorded fixture and
+  assert output
+
+#### Scenario: Time to first result
+- **WHEN** a new user follows the README
+- **THEN** the path from `pip install` to a first rendered result SHALL require
+  no more than the three commands above and no reading beyond their own output

--- a/openspec/changes/0001-foundation-data-and-cli/tasks.md
+++ b/openspec/changes/0001-foundation-data-and-cli/tasks.md
@@ -161,6 +161,34 @@ Estimates are focused hours. Each task names the test that proves it.
       → `tests/cli/test_cache_commands.py::test_clear_requires_confirmation`
 - [ ] **C4. `qf config` group** (1h) — `set`, `show` (masked), `path`.
       → `tests/cli/test_config_commands.py::test_show_masks_api_keys`
+- [ ] **C4b. Settings registry** (2h)
+      `settings.py`: `@setting` declarations with env, secret, required,
+      description, obtain, optional live validator; `qf config set|show`
+      re-pointed at it.
+      → `tests/cli/test_settings.py::test_every_env_var_read_is_a_declared_setting`,
+        `::test_config_show_masks_secrets_to_last_four`
+- [ ] **C4c. `qf init`** (3h)
+      Rich-prompt wizard over the registry; no-echo secrets; idempotent re-run
+      showing masked current values; live validation with consent;
+      `--non-interactive`; sets up storage; ends by running doctor and printing
+      one first command; first-run hint on other commands.
+      → `tests/cli/test_init.py::test_rerun_without_changes_is_byte_identical`,
+        `::test_non_interactive_missing_required_exits_3_naming_it`,
+        `::test_failed_live_validation_never_stores_silently`,
+        `::test_ends_by_running_doctor`
+- [ ] **C4d. `qf doctor`** (3h)
+      `Check` registry with `run` and optional `fix`; the 0001 check set;
+      grouped TTY rendering and `--format json`; exit 0/1 with `--strict`;
+      `--offline`; 5s network caps; `--fix` never touches secrets.
+      → `tests/cli/test_doctor.py::test_every_setting_and_provider_has_a_check`,
+        `::test_failure_lines_always_carry_a_next_step`,
+        `::test_offline_skips_rather_than_fails`,
+        `::test_fix_never_writes_a_secret`,
+        `::test_warnings_do_not_change_exit_code_without_strict`
+- [ ] **C4e. `qf upgrade`** (1h)
+      Installer detection (pip / pipx / uv / container); exact command;
+      confirmation; `--check`.
+      → `tests/cli/test_upgrade.py::test_detects_installer_and_prints_matching_command`
 - [ ] **C5. Disclaimer footer** (0.5h) — table format only.
       → `tests/cli/test_disclaimer.py::test_absent_from_json_and_csv`
 
@@ -171,7 +199,9 @@ Estimates are focused hours. Each task names the test that proves it.
       re-recording is a reviewable diff rather than an ad-hoc action.
 - [ ] **D2. README quickstart** (1h) — install, the three `qf data` commands, the
       no-key promise, and the not-advice disclaimer.
-- [ ] **D3. CI green** (1h) — ruff, ruff format, mypy --strict, pytest on 3.11+3.12.
+- [ ] **D3. CI green** (1.5h) — ruff, ruff format, mypy --strict, pytest; the
+      build job's clean-venv smoke extended to `qf init --non-interactive` →
+      `qf doctor --offline` → one data command on a fixture.
 - [ ] **D4. Port reuse audit** (1h)
       Diff `NewsWaveMetrics/fetch_yfinance.py` and `extract_economic_data.py` against
       B4/B5; lift anything that handles a real-world edge case these specs missed.
@@ -181,8 +211,9 @@ Estimates are focused hours. Each task names the test that proves it.
       per the placement rule in `design.md`.
       → `tests/test_architecture.py::test_core_imports_no_logging_or_tracing`
 
-**Total: ~58h** (was ~27h; the storage port and observability added ~19h, the
-currency model ~5h, the registry, test scaffolding, and data quality ~7h). Wave B is the critical path; B6 and B0b are the tasks with
+**Total: ~67h** (was ~27h; the storage port and observability added ~19h, the
+currency model ~5h, the registry, test scaffolding, and data quality ~7h,
+onboarding ~9h). Wave B is the critical path; B6 and B0b are the tasks with
 real unknowns.
 
 ## Definition of done
@@ -195,6 +226,8 @@ real unknowns.
 - [ ] stdout is byte-identical across log levels and with tracing on and off
 - [ ] No call site outside `data/currency.py` multiplies or divides by a rate
 - [ ] A single-currency run fetches no rates and matches a no-conversion build
+- [ ] `pip install` → `qf init --non-interactive` → `qf doctor --offline` exits 0 in a clean venv, in CI
+- [ ] Every env var the code reads is a declared setting; every setting and provider has a doctor check
 - [ ] No Typer command exists that is not a registry declaration
 - [ ] `tests/architecture/` and `tests/invariants/` run against every registered command
 - [ ] `pytest -m "not network"` passes with networking disabled

--- a/openspec/changes/0004-web-ui/design.md
+++ b/openspec/changes/0004-web-ui/design.md
@@ -77,6 +77,32 @@ update. `core/` still emits nothing itself.
 SSE over websockets: one direction is all that is needed, it works through every
 proxy, and reconnection is a browser primitive rather than a protocol to write.
 
+## `qf open`: terminal to browser in one command
+
+```
+qf open [target]
+   │
+   ├─ server answering on the port and it is ours?  → launch browser, exit 0
+   ├─ something else on the port?                    → error, suggest --port
+   └─ nothing?                                       → serve on loopback
+                                                        wait for /health
+                                                        launch browser
+                                                        run until Ctrl-C
+```
+
+Launching goes through Python's `webbrowser` module, which honors `BROWSER`
+and knows each platform's opener. Its failure is the signal for headless:
+no display, an SSH session, or the container all end the same way — the URL is
+printed and the command exits 0. The URL is printed *before* the launch attempt
+in every case, so a user whose browser opens on the wrong monitor still has
+it. Printing a URL is never an error; the command's job is to get the user to
+the app, and the URL is the app.
+
+Targets map to the frontend view manifest — the same file the parity test
+reads — so `qf open` can reach exactly the views that exist and rejects
+others with the list. `qf init --web` is `qf open settings`; `qf serve --open`
+is `qf serve` plus the launch. One mechanism, three entry points.
+
 ## Access model
 
 | Bind address | Token |
@@ -125,4 +151,6 @@ not just in the test suite.
 | Single in-process worker | Worker pool, Celery, RQ | Single-user process; one worker answers every concurrency question by construction |
 | SSE | WebSockets | One direction suffices; proxies and reconnection are solved problems |
 | Deployment token | User accounts | Multi-user is out of scope; a fake account model is debt |
+| `qf open` targets from the view manifest | A hand-maintained target list | The manifest already exists for parity; a second list would drift from it |
+| Headless prints the URL and exits 0 | Error when no browser | The URL *is* the app; failing to launch a browser is not failing the user |
 | Frontend manifest for parity | Trusting the view list | Parity must fail Python CI, where the registry is |

--- a/openspec/changes/0004-web-ui/proposal.md
+++ b/openspec/changes/0004-web-ui/proposal.md
@@ -11,7 +11,9 @@ planning_depth: proposal + 2 spec deltas + design (tasks written when 0003 lands
 ## Outcome
 
 ```bash
-qf serve                      # http://127.0.0.1:8787
+qf open                       # starts the server if needed, opens the browser
+qf open doctor                # straight to a view: settings, doctor, runs, run 42, ...
+qf serve                      # http://127.0.0.1:8787, no browser
 qf serve --host 0.0.0.0 --port 8787   # prints a token; required to bind non-local
 ```
 
@@ -48,7 +50,8 @@ show, and "watch the frontier solve" is the demo.
 - **Job execution** — optimizations and backtests run as jobs persisted through
   0003's repositories, with progress streamed over SSE. Trace context and run id
   are persisted with the job, so work that outlives its request stays traceable.
-- `qf serve` as the entry point; `[web]` extra for FastAPI and uvicorn.
+- `qf serve` as the entry point and `qf open` as the one-command path from
+  terminal to browser; `[web]` extra for FastAPI and uvicorn.
 
 ## The parity problem, and how it is solved
 

--- a/openspec/changes/0004-web-ui/specs/web-ui/spec.md
+++ b/openspec/changes/0004-web-ui/specs/web-ui/spec.md
@@ -48,6 +48,32 @@
 - **AND** it SHALL update live as fields change, so the UI teaches the CLI rather
   than replacing it
 
+### Requirement: Settings and health in the UI
+
+#### Scenario: Settings page is generated
+- **WHEN** the settings view renders
+- **THEN** every setting declared in 0001's settings registry SHALL appear as a
+  field, with its description and how-to-obtain link, secrets masked and never
+  echoed back
+- **AND** saving SHALL write through the same code path as `qf config set`
+
+#### Scenario: Live validation in the browser
+- **WHEN** a setting with a live validator is saved
+- **THEN** the UI SHALL offer to verify it and show the result, mirroring
+  `qf init`
+
+#### Scenario: Doctor has a view
+- **WHEN** the health view renders
+- **THEN** it SHALL show `qf doctor`'s checks with the same statuses, messages,
+  and next steps, from the same check registry
+- **AND** a check with a registered fix SHALL offer to run it, never touching a
+  secret
+
+#### Scenario: `qf init --web`
+- **WHEN** `qf init --web` runs once this change has landed
+- **THEN** it SHALL start the server bound to loopback and open the settings
+  page, as the browser form of the same wizard
+
 ### Requirement: Dark mode
 
 #### Scenario: Dark by default

--- a/openspec/changes/0004-web-ui/specs/web-ui/spec.md
+++ b/openspec/changes/0004-web-ui/specs/web-ui/spec.md
@@ -71,8 +71,55 @@
 
 #### Scenario: `qf init --web`
 - **WHEN** `qf init --web` runs once this change has landed
-- **THEN** it SHALL start the server bound to loopback and open the settings
-  page, as the browser form of the same wizard
+- **THEN** it SHALL behave as `qf open settings`, the browser form of the same
+  wizard
+
+### Requirement: Launching the UI from the CLI
+
+The browser is one command away from the terminal, and never the only way in.
+
+#### Scenario: `qf open`
+- **WHEN** `qf open` runs and no server is listening on the configured port
+- **THEN** it SHALL start the server bound to loopback, wait for the health
+  endpoint to pass, open the default browser to the app, and keep serving until
+  interrupted
+- **AND** the URL SHALL be printed to stderr before the browser is launched, so
+  it is available even if the launch fails
+
+#### Scenario: Server already running
+- **WHEN** `qf open` runs and a quantfolio server already answers on the port
+- **THEN** it SHALL open the browser to that server and exit 0 without starting
+  a second one
+- **AND** a non-quantfolio process on the port SHALL produce an error naming the
+  port and suggesting `--port`
+
+#### Scenario: Targets
+- **WHEN** `qf open <target>` runs
+- **THEN** `target` SHALL accept `settings`, `doctor`, `runs`, `run <id>`,
+  `portfolio <name>`, and any registry command name, opening that view directly
+- **AND** the accepted set SHALL be derived from the frontend view manifest, so
+  a view that exists is always reachable and one that does not is rejected with
+  the list of those that are
+
+#### Scenario: Headless is not an error
+- **WHEN** no browser can be launched — no display, an SSH session, or inside
+  the container
+- **THEN** `qf open` SHALL print the URL and exit 0
+- **AND** `--print-url` SHALL force that behavior anywhere
+
+#### Scenario: Browser choice is respected
+- **WHEN** the `BROWSER` environment variable is set
+- **THEN** it SHALL be honored, via the platform's standard launcher
+
+#### Scenario: Never a token in the URL
+- **WHEN** the server requires a token
+- **THEN** `qf open` SHALL open the app's entry page and the user SHALL paste the
+  token once there, per `http-api`; the token SHALL NOT be placed in the URL
+
+#### Scenario: `qf serve --open`
+- **WHEN** `qf serve --open` runs
+- **THEN** it SHALL behave as `qf serve` followed by the browser launch above,
+  once healthy
 
 ### Requirement: Dark mode
 

--- a/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
+++ b/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
@@ -81,6 +81,13 @@
   non-root user, resolved database URL, configured settings — with the same
   actionable lines as a local install
 
+#### Scenario: `qf open` in the container
+- **WHEN** `docker run <image> open` runs
+- **THEN** it SHALL print the URL to reach the UI from the host — using the
+  published port when it can be determined, and the container port with a note
+  otherwise — and exit 0
+- **AND** SHALL NOT attempt to launch a browser, since there is none
+
 #### Scenario: Non-interactive init in the container
 - **WHEN** `qf init` runs inside the container
 - **THEN** it SHALL default to `--non-interactive`, reading settings from the

--- a/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
+++ b/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
@@ -72,6 +72,20 @@
 - **WHEN** the image is running `serve`
 - **THEN** a health endpoint SHALL report readiness
 - **AND** the image SHALL declare a `HEALTHCHECK` against it
+- **AND** both SHALL run 0001's doctor checks rather than a separate notion of
+  health
+
+#### Scenario: Doctor in the container
+- **WHEN** `docker run <image> doctor` runs
+- **THEN** it SHALL diagnose the container's own install — `/data` writability,
+  non-root user, resolved database URL, configured settings — with the same
+  actionable lines as a local install
+
+#### Scenario: Non-interactive init in the container
+- **WHEN** `qf init` runs inside the container
+- **THEN** it SHALL default to `--non-interactive`, reading settings from the
+  environment, and SHALL exit 3 naming any missing required value rather than
+  block on a prompt
 
 #### Scenario: Signals
 - **WHEN** the container receives SIGTERM
@@ -182,7 +196,8 @@
 
 #### Scenario: Preflight
 - **WHEN** `qf deploy check` runs
-- **THEN** it SHALL report the image and version, the resolved database path and
+- **THEN** it SHALL run doctor's checks plus the deployment-specific ones below
+- **AND** it SHALL report the image and version, the resolved database path and
   whether it is writable, the bind address and port, whether a token is required
   and configured, and which credentials are present — naming each by key only
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -115,6 +115,7 @@ site/                       # 0006: animated landing page → GitHub Pages
 | `qf run list` / `qf run show <id>` | Browse saved analysis runs |
 | `qf db info` / `qf db export --to ...` | Inspect and back up the database |
 | `qf serve --host 0.0.0.0` | Run the web UI and API |
+| `qf open [doctor\|settings\|run 42\|...]` | Start the server if needed and open the browser to a view |
 | `qf deploy compose` / `qf deploy check` | Generate and verify a deployment |
 
 ## Data sources
@@ -243,7 +244,7 @@ Each is one OpenSpec change under `openspec/changes/`.
 | 0001 | `foundation-data-and-cli` | Onboarding (`init`/`doctor`/`upgrade`), command registry, storage port + SQLite adapter, providers, data quality, currency model, logging + tracing, test scaffolding, `qf data *` |
 | 0002 | `portfolio-optimization` | **v1.0.0** — returns/risk, MVO, frontier, backtest |
 | 0003 | `local-persistence` | Schema + migrations, saved portfolios/goals/runs, `qf db` |
-| 0004 | `web-ui` | API and UI derived from the registry, React SPA, jobs + SSE, `qf serve` |
+| 0004 | `web-ui` | API and UI derived from the registry, React SPA, jobs + SSE, `qf serve`, `qf open` |
 | 0005 | `docker-distribution` | One image on Docker Hub, CLI entrypoint, `qf deploy` |
 | 0006 | `landing-page` | Animated dark GitHub Pages site |
 | 0007 | `equity-factor-analysis` | Single-stock analysis, CAPM, Fama-French 3/5 + momentum |

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -92,6 +92,9 @@ site/                       # 0006: animated landing page → GitHub Pages
 
 | Command | Does |
 |---|---|
+| `qf init` | Guided setup of every declared setting; ends by running doctor |
+| `qf doctor` | Every check actionable; `--fix` for safe repairs; `--format json` |
+| `qf upgrade` | Detects the installer and runs the matching upgrade |
 | `qf data prices AAPL MSFT --start 2015-01-01` | Fetch + cache price history |
 | `qf data macro DGS10 CPIAUCSL` | Fetch FRED series |
 | `qf analyze stock NVDA` | Fundamentals, risk, CAPM beta |
@@ -128,6 +131,26 @@ site/                       # 0006: animated landing page → GitHub Pages
 `pip install quantfolio-cli` must produce a working tool with **no keys
 configured**. Anything requiring a key degrades with a clear, actionable error —
 never a stack trace.
+
+## Onboarding
+
+Three commands, kept to three by construction:
+
+```
+pip install quantfolio-cli  →  qf init  →  qf doctor
+```
+
+**Settings are declared once**, like commands. Each carries its env var, whether
+it is a secret, how to obtain it, and an optional live validator; `qf init`,
+`qf doctor`, `qf config`, and the 0004 settings page all derive from the
+declaration. A test asserts every env var the code reads is a declared setting.
+
+**Doctor's checks are declared once**, too — a `Check` registry with `run` and
+an optional idempotent `fix`. A milestone that adds a provider, a setting, or a
+runtime dependency registers a check in the same change; a test asserts every
+setting and provider has one. Every failing line carries its next step. `qf
+deploy check` and the container health check call doctor rather than
+re-implementing health.
 
 ## Storage: a port, with SQLite behind it
 
@@ -217,7 +240,7 @@ Each is one OpenSpec change under `openspec/changes/`.
 | # | Change | Ships |
 |---|---|---|
 | 0000 | `release-engineering` | CI gate, version-gated PyPI publishing |
-| 0001 | `foundation-data-and-cli` | Command registry, storage port + SQLite adapter, providers, data quality, currency model, logging + tracing, test scaffolding, `qf data *` |
+| 0001 | `foundation-data-and-cli` | Onboarding (`init`/`doctor`/`upgrade`), command registry, storage port + SQLite adapter, providers, data quality, currency model, logging + tracing, test scaffolding, `qf data *` |
 | 0002 | `portfolio-optimization` | **v1.0.0** — returns/risk, MVO, frontier, backtest |
 | 0003 | `local-persistence` | Schema + migrations, saved portfolios/goals/runs, `qf db` |
 | 0004 | `web-ui` | API and UI derived from the registry, React SPA, jobs + SSE, `qf serve` |
@@ -247,5 +270,8 @@ came before it.
    never appear in signatures outside their adapter.
 7. **Observability never changes behavior.** No secret in a log or a span, no
    log on stdout, no instrumentation inside `core/`.
-8. **No forecasting of exchange rates, ever.** PPP is reported as a valuation
+8. **Onboarding stays three commands.** A milestone that adds a key, provider,
+   or dependency declares a setting and a doctor check in the same change, and
+   the build fails if it does not.
+9. **No forecasting of exchange rates, ever.** PPP is reported as a valuation
    gap, never as a signal, a target, or a convergence path.

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,99 @@
+"""Contract tests for ``.github/scripts/check_release.py``.
+
+The script's stdout is appended to ``$GITHUB_OUTPUT``, which accepts only
+``key=value`` lines and fails the job on anything else. These tests run every
+decision path with the index call stubbed and assert that contract, so a stray
+informational print can never again turn a push to ``main`` red.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "check_release.py"
+
+# What $GITHUB_OUTPUT will accept: a bare key, "=", then anything.
+OUTPUT_LINE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+
+
+def load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_release", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    target: str,
+    enabled: str,
+    index: Callable[[str, str], set[str] | None],
+) -> tuple[dict[str, str], str]:
+    """Run ``main()`` and return parsed stdout outputs plus raw stderr."""
+    module = load_script()
+    monkeypatch.setenv("TARGET", target)
+    monkeypatch.setenv("RELEASE_ENABLED", enabled)
+    monkeypatch.setattr(module, "released_versions", index)
+    module.main()
+    out, err = capsys.readouterr()
+
+    lines = [line for line in out.splitlines() if line.strip()]
+    for line in lines:
+        assert OUTPUT_LINE.match(line), (
+            f"stdout line is not key=value and would fail $GITHUB_OUTPUT: {line!r}"
+        )
+    return dict(line.split("=", 1) for line in lines), err
+
+
+def test_disarmed_publishes_nothing_and_keeps_stdout_clean(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    outputs, err = run(monkeypatch, capsys, target="pypi", enabled="", index=lambda *_: None)
+    assert outputs["publish"] == "false"
+    assert outputs["target"] == "pypi"
+    assert "not armed" in err, "the human explanation belongs on stderr"
+
+
+def test_armed_first_release_publishes(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    outputs, _ = run(monkeypatch, capsys, target="pypi", enabled="true", index=lambda *_: None)
+    assert outputs["publish"] == "true"
+
+
+def test_armed_existing_version_publishes_nothing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from quantfolio import __version__
+
+    outputs, err = run(
+        monkeypatch, capsys, target="pypi", enabled="true", index=lambda *_: {__version__}
+    )
+    assert outputs["publish"] == "false"
+    assert "already on pypi" in err
+
+
+def test_testpypi_rehearsal_ignores_arming(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    outputs, _ = run(monkeypatch, capsys, target="testpypi", enabled="", index=lambda *_: None)
+    assert outputs["publish"] == "true"
+    assert outputs["target"] == "testpypi"
+
+
+def test_every_mode_emits_exactly_the_three_outputs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for target, enabled in (("pypi", ""), ("pypi", "true"), ("testpypi", "")):
+        outputs, _ = run(monkeypatch, capsys, target=target, enabled=enabled, index=lambda *_: None)
+        assert set(outputs) == {"version", "target", "publish"}, (target, enabled, outputs)


### PR DESCRIPTION
Three commits: a one-script fix for the red Release run on `main`, the onboarding spec, and `qf open`. All on the designated branch, so they ride together.

## 1. Fix: Release workflow red on `main`

The first push to `main` after merging #2 failed in under a second:

```
##[error]Invalid format 'See docs/RELEASING.md for the one-time Trusted Publishing setup.'
```

`check_release.py` printed its human-readable messages to **stdout**, and `release.yml` appends stdout to `$GITHUB_OUTPUT`, which accepts only `key=value` lines. All three decision paths had it; the disarmed path just ran first. My local check printed the same lines and looked fine because nothing parsed stdout the way the runner does — the exact rule the observability spec states ("stdout carries results, everything human goes to stderr"), broken in the one script that feeds a machine interface.

**Fix:** the script has exactly two writers now — `note()` → stderr, `emit()` → stdout for `key=value` only. **Guard:** `tests/test_release_script.py` runs every mode with the index stubbed and asserts each stdout line matches what `$GITHUB_OUTPUT` accepts. Also reproduced the runner's parse locally across all three modes. No workflow change; it was right to fail.

After merge, Release on `main` should report **"not armed"** and pass — the correct state until the four owner steps in `docs/RELEASING.md` are done.

## 2. Spec: onboarding, in 0001

The user's path becomes three commands, and stays three by construction:

```
pip install quantfolio-cli  →  qf init  →  qf doctor
```

**Settings are declared once**, like commands. Each carries its env var, secret flag, how to obtain it, and an optional live validator; `qf init`, `qf doctor`, `qf config`, and the 0004 settings page all derive from that. A test asserts every env var the code reads is a declared setting — reading `os.environ` directly fails the build.

**Doctor's checks are declared once**, too. A milestone that adds a provider, setting, or dependency registers a `Check` in the same change; a test asserts every setting and provider has one. Every failing line carries its next step. `qf deploy check` and the container `HEALTHCHECK` call doctor rather than re-implementing health.

| Command | Behavior |
|---|---|
| `qf init` | Guided Rich-prompt wizard; idempotent re-run with masked values; live key verification with consent, never silently storing a key that just failed; `--non-interactive` exits 3 naming a missing required value rather than hanging a container; sets up storage; **ends by running doctor and printing one runnable first command** |
| `qf doctor` | Exit 0 unless a check fails (`--strict` promotes warnings); every network check capped at 5s; `--offline` → skipped, not failed; `--fix` applies safe repairs and **never touches a secret**; `--format json` |
| `qf upgrade` | Detects pip / pipx / uv / container, prints the matching command, confirms before running; `--check` only reports |

The three-command path is itself a CI test: the build job's clean-venv smoke extends to `init --non-interactive` → `doctor --offline` → one data command on a fixture.

"GUI" is read as a guided terminal wizard since you said "in the CLI itself"; 0004 gains a settings page and doctor view from the same registries. Say so if you meant a web page from day one.

Also hooked into 0005: `docker run <image> doctor` diagnoses the container's own install, and `qf init` inside the container defaults to non-interactive.

## 3. Spec: `qf open`, in 0004

Terminal to browser in one command:

```bash
qf open            # server already up → launch browser; else serve on loopback, wait for health, launch, run until Ctrl-C
qf open doctor     # straight to a view: settings, doctor, runs, run 42, portfolio core, any registry command
qf serve --open    # serve + launch
```

Targets are derived from the frontend view manifest the parity test already reads, so `qf open` reaches exactly the views that exist and rejects others with the list. **Headless is not an error** — no display, SSH, or the container all print the URL and exit 0, and the URL is printed *before* the launch attempt in every case. `BROWSER` is honored via the platform opener. A token is never placed in the URL. `qf init --web` becomes `qf open settings`. In 0005, `docker run <image> open` prints the host-reachable URL and never tries to launch a browser.

**0001: 58h → 67h; 0004: 70h → 72h; v1.0.0 ~115h.** Spec and docs only — no code beyond the release-script fix.

## Verified locally

ruff, ruff format, actionlint, `mypy --strict`, pytest (16 tests, 100% coverage), the `$GITHUB_OUTPUT` simulation, and every `depends_on` resolving.