### PR TITLE
Rebrand to sobres, move to AISL org, wire org PyPI secrets

### DIFF
--- a/openspec/changes/0000-release-engineering/proposal.md
+++ b/openspec/changes/0000-release-engineering/proposal.md
@@ -10,10 +10,10 @@ status: proposed
 ## Outcome
 
 Merging a version bump to `main` publishes the package to PyPI, with no manual
-upload step and no API token stored anywhere:
+upload step and no credential living in this repository:
 
 ```
-bump src/quantfolio/__about__.py  +  add a CHANGELOG.md section  →  merge  →  live on PyPI
+bump src/sobres/__about__.py  +  add a CHANGELOG.md section  →  merge  →  live on PyPI
 ```
 
 Every other push to `main` publishes nothing and says so.
@@ -41,8 +41,10 @@ added after the code is written never catches what it would have prevented.
 - `.github/workflows/codeql.yml`, `.github/dependabot.yml`,
   `.pre-commit-config.yaml`, `CHANGELOG.md`, `docs/RELEASING.md`.
 - `tests/test_packaging.py` — release invariants enforced by `pytest`.
-- Distribution renamed to `quantfolio-cli`; the import package and both console
-  scripts stay `quantfolio` / `qf`.
+- Distribution named `sobres`; the import package is `sobres` and the console
+  script is `sobres`.
+- Publishing authenticates with the organization-level secrets `PYPI_PROD` and
+  `PYPI_TEST`, which every `AI-Solutions-Lab-LLC` repository shares.
 
 ## Non-goals
 
@@ -62,7 +64,8 @@ added after the code is written never catches what it would have prevented.
 |---|---|
 | Merging the pipeline fires a publish before PyPI is configured, producing a red run on `main` | Publishing is disarmed until the repository variable `RELEASE_ENABLED` is `true`; `decide` reports "not armed" and exits clean |
 | A network blip makes the index look empty, and a published version is re-published | `check_release.py` fails closed on any non-404 error rather than treating an unreachable index as "nothing published" |
+| The organization PyPI token leaks and every repository in the organization is exposed | The token is org-scoped by design, so the blast radius is the organization. It is never echoed, the `pypi` environment can require human approval, and rotation is one place. Trusted Publishing would remove the token entirely and is the upgrade path once the org is ready for it |
 | A bad version reaches PyPI, where it can never be replaced | `verify` re-runs the whole CI gate on the release commit; the wheel is installed in a clean environment and executed before upload; the `pypi` environment can require a human approval |
 | The release gate drifts from the PR gate as CI grows | `release.yml` calls `ci.yml` via `workflow_call`; there is one definition of "green" |
 | A required check is silently skipped and reads as passing | The `all-green` aggregator treats `skipped` and `cancelled` as failures, and it is the only required status check |
-| `quantfolio` is taken on PyPI by an unrelated 2019 package | Ship as `quantfolio-cli`; a PEP 541 name transfer request can be filed separately and changes nothing structurally if it succeeds |
+| The distribution name is unavailable on PyPI at release time | `sobres` was unclaimed as of 2026-09-12 (PyPI returns 404). `check_release.py` fails closed if the name is claimed by anyone else before the first upload, and the name is reserved by publishing `0.0.0` early |

--- a/openspec/changes/0000-release-engineering/specs/release-pipeline/spec.md
+++ b/openspec/changes/0000-release-engineering/specs/release-pipeline/spec.md
@@ -20,7 +20,7 @@ The release gate SHALL be the same workflow as the pull-request gate, not a copy
 ### Requirement: Version-gated publishing
 
 Publishing SHALL be driven by the version declared in
-`src/quantfolio/__about__.py`, because index versions are immutable.
+`src/sobres/__about__.py`, because index versions are immutable.
 
 #### Scenario: New version on main
 - **WHEN** a push to `main` declares a version absent from the target index
@@ -56,17 +56,64 @@ Publishing SHALL be driven by the version declared in
 - **WHEN** the workflow is dispatched manually with target `testpypi`
 - **THEN** it SHALL publish to TestPyPI regardless of `RELEASE_ENABLED`
 
-### Requirement: No long-lived publishing credential
+### Requirement: `main` is reachable only through a reviewed pull request
 
-#### Scenario: Trusted Publishing
-- **WHEN** the pipeline uploads to an index
-- **THEN** it SHALL authenticate via OIDC with `id-token: write`
-- **AND** no PyPI API token SHALL exist in repository secrets
+`main` SHALL be a protected branch. Every commit SHALL arrive through a pull
+request that passed the gate, and merging SHALL be restricted to repository
+administrators.
 
-#### Scenario: Attested artifacts
-- **WHEN** a distribution is published
-- **THEN** PEP 740 attestations SHALL be generated, binding the artifact to the
-  workflow and repository that built it
+#### Scenario: No direct push
+- **WHEN** anyone pushes directly to `main`
+- **THEN** the push SHALL be rejected
+
+#### Scenario: The gate is required, not advisory
+- **WHEN** a pull request targets `main`
+- **THEN** the `All checks passed` status SHALL be required
+- **AND** the branch SHALL be required to be up to date with `main` before merging
+- **AND** unresolved review conversations SHALL block the merge
+
+#### Scenario: Only administrators merge
+- **WHEN** a non-administrator attempts to merge a pull request into `main`
+- **THEN** the merge SHALL be refused
+
+#### Scenario: History stays linear and recoverable
+- **WHEN** `main` is updated
+- **THEN** linear history SHALL be required
+- **AND** force pushes and branch deletion SHALL be refused
+
+### Requirement: Publishing credentials come from organization secrets
+
+Publishing SHALL authenticate with organization-level secrets. The
+`AI-Solutions-Lab-LLC` organization holds one PyPI API token per index, shared by
+every repository in it; no repository SHALL store its own copy.
+
+#### Scenario: Production upload
+- **WHEN** the pipeline uploads to PyPI
+- **THEN** it SHALL authenticate with the organization secret `PYPI_PROD`
+- **AND** SHALL NOT read any repository-level PyPI secret
+
+#### Scenario: Rehearsal upload
+- **WHEN** the pipeline uploads to TestPyPI
+- **THEN** it SHALL authenticate with the organization secret `PYPI_TEST`
+
+#### Scenario: One definition of the credential
+- **WHEN** the repository's own Actions secrets are listed
+- **THEN** neither `PYPI_PROD` nor `PYPI_TEST` SHALL appear there
+- **AND** a repository-level secret of either name SHALL be treated as a
+  configuration error, because it silently shadows the organization value
+
+#### Scenario: The token never reaches a log
+- **WHEN** any job runs at any log level
+- **THEN** the token SHALL be passed only as the upload action's password input
+- **AND** SHALL NOT be echoed, written to a file, or exported to a step that
+  prints its environment
+
+#### Scenario: No attestations under token auth
+- **WHEN** a distribution is published with an API token
+- **THEN** PEP 740 attestations SHALL NOT be claimed or expected, since they are
+  produced only by Trusted Publishing's OIDC identity
+- **AND** the release notes SHALL NOT assert provenance the pipeline does not
+  generate
 
 #### Scenario: Least privilege
 - **WHEN** any workflow runs

--- a/openspec/changes/0000-release-engineering/tasks.md
+++ b/openspec/changes/0000-release-engineering/tasks.md
@@ -36,8 +36,8 @@ All complete. Recorded so the change archives with its own checklist.
 - [x] **C5. Packaging tests** — `tests/test_packaging.py`: version format,
       installed metadata parity, changelog section, both entry points.
 - [x] **C6. `docs/RELEASING.md`** — the one-time setup and the failure playbook.
-- [x] **C7. Distribution rename** to `quantfolio-cli`; `quantfolio` on PyPI is
-      held by an unrelated 2019 package.
+- [x] **C7. Distribution name** is `sobres`, unclaimed on PyPI as of 2026-09-12.
+      An earlier `quantfolio` / `quantfolio-cli` naming is superseded by change 0011.
 
 ## Definition of done
 
@@ -45,6 +45,10 @@ All complete. Recorded so the change archives with its own checklist.
 - [x] Coverage at 100%, CI gate set at 90%
 - [x] `check_release.py` verified against the live index in every mode
 - [x] Every workflow parses as valid YAML
-- [ ] **Owner action:** Trusted Publishing configured, `pypi` / `testpypi`
-      environments created, `RELEASE_ENABLED` set, `main` protected
-      (see `docs/RELEASING.md`)
+- [ ] **Owner action:** `pypi` / `testpypi` environments created and wired to the
+      organization secrets `PYPI_PROD` and `PYPI_TEST`, `RELEASE_ENABLED` set,
+      `main` protected (see `docs/RELEASING.md`)
+- [ ] **B5. Token-auth upload** — `release.yml` passes `secrets.PYPI_PROD` /
+      `secrets.PYPI_TEST` as the upload password and drops the `id-token: write`
+      permission and the attestation step. → test: a TestPyPI rehearsal uploads
+      successfully and the run log contains no token fragment.

--- a/openspec/changes/0000-release-engineering/tasks.md
+++ b/openspec/changes/0000-release-engineering/tasks.md
@@ -45,9 +45,21 @@ All complete. Recorded so the change archives with its own checklist.
 - [x] Coverage at 100%, CI gate set at 90%
 - [x] `check_release.py` verified against the live index in every mode
 - [x] Every workflow parses as valid YAML
-- [ ] **Owner action:** `pypi` / `testpypi` environments created and wired to the
-      organization secrets `PYPI_PROD` and `PYPI_TEST`, `RELEASE_ENABLED` set,
-      `main` protected (see `docs/RELEASING.md`)
+### Owner actions
+
+- [x] `main` protected — pull request required, `All checks passed` required,
+      strict up-to-date branches, admin-only merge, linear history, no force push
+      or deletion. Configured 2026-09-12.
+- [x] `pypi` and `testpypi` environments created. Configured 2026-09-12.
+- [x] `RELEASE_ENABLED` repository variable exists and is `false`. Publishing is
+      deliberately disarmed until 0011 lands, because the code still declares the
+      old distribution name and arming now would publish it under a name nobody
+      wants and can never delete.
+- [ ] Add required reviewers to the `pypi` environment, making every production
+      publish an approval gate.
+- [ ] Set `RELEASE_ENABLED` to `true` — only after 0011 renames the distribution
+      and B5 switches the upload to token auth.
+- [ ] Reserve `sobres` on PyPI by publishing `0.0.0` once armed.
 - [ ] **B5. Token-auth upload** — `release.yml` passes `secrets.PYPI_PROD` /
       `secrets.PYPI_TEST` as the upload password and drops the `id-token: write`
       permission and the attestation step. → test: a TestPyPI rehearsal uploads

--- a/openspec/changes/0001-foundation-data-and-cli/design.md
+++ b/openspec/changes/0001-foundation-data-and-cli/design.md
@@ -3,7 +3,7 @@
 ## Layering
 
 ```
-qf data prices AAPL
+sobres data prices AAPL
       │
       ▼
 cli/commands/data.py ──► data/yfinance_provider.py ──► data/cache.py
@@ -53,7 +53,7 @@ every command and no command formats its own output.
 
 ## Onboarding: settings and checks are registries
 
-The user's path is `pip install` → `qf init` → `qf doctor`, and the design
+The user's path is `pip install` → `sobres init` → `sobres doctor`, and the design
 problem is keeping it that short as ten milestones add keys, providers, and
 runtime dependencies. The answer is the same one the command registry gives:
 declare once, derive everywhere.
@@ -70,8 +70,8 @@ class FredApiKey:
     def validate_live(self, value: str) -> CheckResult: ...   # one cheap request
 ```
 
-From that one declaration: `qf init` prompts (no echo, masked on re-run, live
-verification offered), `qf doctor` checks presence and validity, `qf config
+From that one declaration: `sobres init` prompts (no echo, masked on re-run, live
+verification offered), `sobres doctor` checks presence and validity, `sobres config
 set|show` accepts it, and 0004 renders a settings field. A milestone that adds
 a key adds a declaration, and gets all four for free — and a test asserts that
 every environment variable the code reads is a declared setting, so the
@@ -80,16 +80,16 @@ shortcut of reading `os.environ` directly fails the build.
 Doctor is the same shape: a `Check` registry with `run` and an optional
 idempotent `fix`. 0003 registers the migration check, 0004 the server checks,
 0010 the FX provider check. Every line doctor prints carries its next step, on
-the principle that a diagnostic without a fix is a complaint. `qf deploy check`
+the principle that a diagnostic without a fix is a complaint. `sobres deploy check`
 and the container `HEALTHCHECK` (0005) call doctor rather than re-implementing
 health, so there is one definition of "this install works".
 
-`qf init` ends by running doctor and printing one runnable first command
+`sobres init` ends by running doctor and printing one runnable first command
 tailored to what was configured — the last step of onboarding is the first step
 of use.
 
 "GUI" here means a guided terminal wizard built on Rich prompts. 0004's
-settings page is the browser form of the same registry; a `qf init --web` that
+settings page is the browser form of the same registry; a `sobres init --web` that
 opens it is a natural addition there, not here.
 
 ## Storage: a port, not a database
@@ -108,8 +108,8 @@ Note what the port speaks: observations and date ranges, not `SELECT`. A port
 phrased in SQL is a SQL port, and swapping it is then a rewrite. Phrased in the
 domain, a DuckDB or Postgres adapter is a new file and a fixture-list entry.
 
-**`QUANTFOLIO_DB_URL` selects the adapter**, defaulting to
-`sqlite:///<user-data-dir>/quantfolio.db`. Nothing above the adapter knows which
+**`SOBRES_DB_URL` selects the adapter**, defaulting to
+`sqlite:///<user-data-dir>/sobres.db`. Nothing above the adapter knows which
 backend is live.
 
 ### The library underneath
@@ -301,7 +301,7 @@ already on disk.
 One base, narrow leaves, each mapped to an exit code:
 
 ```
-QuantfolioError                 → 1
+SobresError                 → 1
 ├── UsageError                  → 2
 ├── ConfigurationError          → 3   (missing key, bad config file)
 ├── ProviderError               → 4   (network, upstream shape change)
@@ -323,7 +323,7 @@ CSV when piped. Rich's box-drawing in a pipe is the kind of small thing that mak
 a tool feel unusable in a script.
 
 Everything that is not the result — progress, warnings, the disclaimer — goes to
-stderr or is suppressed in machine formats. `qf data prices AAPL --format json | jq`
+stderr or is suppressed in machine formats. `sobres data prices AAPL --format json | jq`
 must never need a `grep -v`.
 
 ## Testing

--- a/openspec/changes/0001-foundation-data-and-cli/proposal.md
+++ b/openspec/changes/0001-foundation-data-and-cli/proposal.md
@@ -9,13 +9,13 @@ status: proposed
 
 ## Outcome
 
-Someone with a fresh `pip install quantfolio` and **no API keys** can run:
+Someone with a fresh `pip install sobres` and **no API keys** can run:
 
 ```bash
-pip install quantfolio-cli
-qf init          # configure keys and storage, interactively; ends by running doctor
-qf doctor        # every check actionable; exit 0 means it works
-qf data prices AAPL MSFT NVDA --start 2015-01-01 --format table
+pip install sobres
+sobres init          # configure keys and storage, interactively; ends by running doctor
+sobres doctor        # every check actionable; exit 0 means it works
+sobres data prices AAPL MSFT NVDA --start 2015-01-01 --format table
 ```
 
 …and get clean tabular output, cached locally, with the second run served from
@@ -45,9 +45,9 @@ the codebase is small enough that the rule is free to follow.
 - **New capability `observability`** — structured logging on by default and
   OpenTelemetry tracing behind an optional extra, instrumenting the adapters and
   the I/O layer while `core/` stays pure.
-- **New capability `onboarding`** — `qf init`, `qf doctor`, `qf upgrade`, and a
+- **New capability `onboarding`** — `sobres init`, `sobres doctor`, `sobres upgrade`, and a
   settings registry they all derive from. Every configurable value is declared
-  once; init prompts for it, doctor checks it, `qf config` accepts it, and the
+  once; init prompts for it, doctor checks it, `sobres config` accepts it, and the
   0004 settings page renders it. Doctor's checks are a registry too, and a test
   asserts every setting and provider has one.
 - **New capability `command-registry`** — every command declared once with a
@@ -66,8 +66,8 @@ the codebase is small enough that the rule is free to follow.
   analytics are 0010; only the model that makes them possible lands here.
 - **New capability `cli-shell`** — root Typer app, `--format table|json|csv`,
   `-v/-vv` and `--log-format`, a config resolution chain, uniform error handling,
-  and the `qf data` / `qf cache` command groups.
-- `src/quantfolio/config.py` — settings from env → config file → defaults.
+  and the `sobres data` / `sobres cache` command groups.
+- `src/sobres/config.py` — settings from env → config file → defaults.
 - Test fixtures: recorded provider payloads under `tests/fixtures/` so the whole
   suite runs offline.
 
@@ -97,8 +97,8 @@ the codebase is small enough that the rule is free to follow.
 |---|---|
 | yfinance is an unofficial, breakage-prone API | Isolate behind `PriceProvider`; pin a known-good version; contract tests against recorded fixtures catch shape drift |
 | Ken French CSVs have irregular, multi-table layouts | Parser is its own tested unit with a checked-in sample; fail loudly on unexpected structure rather than silently mis-slicing |
-| Cached data goes stale mid-analysis | Per-dataset TTL, `qf cache info` shows age, `--refresh` forces a re-fetch |
-| One SQLite file becomes a single point of failure for user-authored state | 0003 adds `qf db export` and a migration story; a corrupt database refuses to be silently recreated |
+| Cached data goes stale mid-analysis | Per-dataset TTL, `sobres cache info` shows age, `--refresh` forces a re-fetch |
+| One SQLite file becomes a single point of failure for user-authored state | 0003 adds `sobres db export` and a migration story; a corrupt database refuses to be silently recreated |
 | Silent timezone/calendar misalignment across sources | One rule, enforced at the data boundary: all series are tz-naive dates on a trading-day index; alignment is an explicit, tested operation |
 | The storage abstraction is designed around SQLite and leaks when a real second backend arrives | The schema is constrained to a documented three-way capability intersection now, not later; identifiers are application-generated; timestamps are explicit UTC; the conformance suite is written against the contract rather than against SQLite's behavior |
 | Abstraction costs more than it saves for a single-user tool | The port is thin — repository protocols plus an expression layer — and no second adapter is built on speculation. If the second backend never arrives, the cost is a few protocol files |
@@ -107,7 +107,7 @@ the codebase is small enough that the rule is free to follow.
 | A rate is applied in the wrong direction | Direction is carried by `CurrencyPair(base, quote)`, call sites never touch a raw rate, and round-trip conversion is a test |
 | A listing quoted in a sub-unit (GBp, ZAc) is read as the major unit | The data layer normalizes to the major unit and a test covers a real pence-quoted listing — a silent hundred-fold error otherwise |
 | A later milestone adds an API key or provider and forgets to make it configurable or diagnosable | Settings and checks are registries; a test asserts every env var the code reads is a declared setting and every setting and provider has a doctor check |
-| `qf init` hangs a container or CI on a prompt | `--non-interactive` takes values from flags and environment only and exits 3 naming any missing required value |
+| `sobres init` hangs a container or CI on a prompt | `--non-interactive` takes values from flags and environment only and exits 3 naming any missing required value |
 | Doctor hangs on a dead network | Every network check has a five-second cap and `--offline` skips them; skipped is not failed |
 | Hand-written commands in 0001 have to be rewritten when 0004 needs API and UI surfaces | The registry lands here; 0004 adds consumers of existing declarations rather than restructuring them |
 | "A test SHALL assert" in later specs never becomes a test | The `testing` spec defines the suites and a scenario-coverage test that fails on an unreferenced scenario once a change is marked implemented |

--- a/openspec/changes/0001-foundation-data-and-cli/specs/cli-shell/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/cli-shell/spec.md
@@ -4,18 +4,18 @@
 
 ### Requirement: Root command and entry points
 
-The system SHALL expose a Typer application as both `qf` and `quantfolio`.
+The system SHALL expose a Typer application as both `sobres` and `sobres`.
 
 #### Scenario: Version
-- **WHEN** `qf --version` runs
+- **WHEN** `sobres --version` runs
 - **THEN** the installed version SHALL print to stdout and exit 0
 
 #### Scenario: Bare invocation
-- **WHEN** `qf` runs with no arguments
+- **WHEN** `sobres` runs with no arguments
 - **THEN** help SHALL print and exit 0 (not an error)
 
 #### Scenario: Command groups
-- **WHEN** `qf --help` runs
+- **WHEN** `sobres --help` runs
 - **THEN** the listed groups SHALL be exactly those shipped so far, each with a
   one-line description
 
@@ -29,7 +29,7 @@ Every command that emits data SHALL support `--format table|json|csv`.
 
 #### Scenario: Piping is machine-readable by default
 - **WHEN** stdout is not a TTY and `--format` is omitted
-- **THEN** output SHALL be CSV, so `qf data prices AAPL > p.csv` just works
+- **THEN** output SHALL be CSV, so `sobres data prices AAPL > p.csv` just works
 
 #### Scenario: JSON is parseable and complete
 - **WHEN** `--format json` is used
@@ -48,14 +48,14 @@ config file → built-in default.
 
 #### Scenario: Config file location
 - **WHEN** no override is set
-- **THEN** the config file SHALL be `<user-config-dir>/quantfolio/config.toml`
+- **THEN** the config file SHALL be `<user-config-dir>/sobres/config.toml`
 
 #### Scenario: Setting a key
-- **WHEN** `qf config set fred_api_key ABC123` runs
+- **WHEN** `sobres config set fred_api_key ABC123` runs
 - **THEN** the key SHALL persist to the config file with mode `0600`
 
 #### Scenario: Secrets are never echoed
-- **WHEN** `qf config show` runs
+- **WHEN** `sobres config show` runs
 - **THEN** any key whose name contains `key`, `token`, or `secret` SHALL render as
   its last 4 characters prefixed by `****`
 
@@ -77,31 +77,31 @@ The CLI SHALL never surface an unhandled traceback for an anticipated failure.
 - **WHEN** `--debug` is passed
 - **THEN** the full traceback SHALL print to stderr in addition to the message
 
-### Requirement: `qf data` command group
+### Requirement: `sobres data` command group
 
 The CLI SHALL expose the data layer directly, so users can inspect the inputs to
 every later calculation.
 
 #### Scenario: Prices
-- **WHEN** `qf data prices AAPL MSFT --start 2020-01-01 --end 2020-12-31` runs
+- **WHEN** `sobres data prices AAPL MSFT --start 2020-01-01 --end 2020-12-31` runs
 - **THEN** a date-indexed table with `AAPL` and `MSFT` columns SHALL print
 
 #### Scenario: Macro
-- **WHEN** `qf data macro DGS10 CPIAUCSL --start 2020-01-01` runs
+- **WHEN** `sobres data macro DGS10 CPIAUCSL --start 2020-01-01` runs
 - **THEN** a date-indexed table of those FRED series SHALL print
 
 #### Scenario: Factors
-- **WHEN** `qf data factors --model ff5 --frequency monthly` runs
+- **WHEN** `sobres data factors --model ff5 --frequency monthly` runs
 - **THEN** a date-indexed table of the FF5 factors plus `RF` SHALL print
 
-### Requirement: `qf cache` command group
+### Requirement: `sobres cache` command group
 
 #### Scenario: Inspect
-- **WHEN** `qf cache info` runs
+- **WHEN** `sobres cache info` runs
 - **THEN** total size on disk, entry count, and oldest entry age SHALL print
 
 #### Scenario: Clear
-- **WHEN** `qf cache clear` runs
+- **WHEN** `sobres cache clear` runs
 - **THEN** the user SHALL be prompted to confirm before any deletion
 - **AND** `--yes` SHALL skip the prompt for scripted use
 

--- a/openspec/changes/0001-foundation-data-and-cli/specs/command-registry/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/command-registry/spec.md
@@ -67,13 +67,13 @@ that 0004 adds surfaces rather than rewriting commands.
 ### Requirement: Introspection
 
 #### Scenario: The registry is queryable
-- **WHEN** `qf commands --format json` runs
+- **WHEN** `sobres commands --format json` runs
 - **THEN** every registered command SHALL be listed with its group, name, help,
   and parameter schema
 - **AND** this SHALL be the source the parity tests in 0004 enumerate
 
 #### Scenario: Registration is complete at import
-- **WHEN** `quantfolio.registry` is imported
+- **WHEN** `sobres.registry` is imported
 - **THEN** every command SHALL be registered
 - **AND** a test SHALL assert the count against an explicit list, so a command
   module that fails to import is caught rather than silently absent

--- a/openspec/changes/0001-foundation-data-and-cli/specs/market-data/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/market-data/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Provider protocols
 
-The system SHALL define three typed protocols in `quantfolio.data.base` that every
+The system SHALL define three typed protocols in `sobres.data.base` that every
 data source implements, so that call sites depend on the protocol and never on a
 concrete vendor.
 
@@ -18,7 +18,7 @@ concrete vendor.
 - **AND** a shared contract test suite SHALL run against every registered provider
 
 #### Scenario: Call sites are vendor-agnostic
-- **WHEN** any code outside `quantfolio.data` needs prices
+- **WHEN** any code outside `sobres.data` needs prices
 - **THEN** it SHALL accept a `PriceProvider` and SHALL NOT import a vendor module
 
 ### Requirement: Canonical price frame shape
@@ -43,7 +43,7 @@ All price data SHALL be returned in one documented shape, regardless of source.
 
 ### Requirement: Explicit series alignment
 
-The system SHALL provide `quantfolio.data.align_frames(*frames, how)` as the single
+The system SHALL provide `sobres.data.align_frames(*frames, how)` as the single
 sanctioned way to combine series from different sources.
 
 #### Scenario: Prices aligned to factor returns
@@ -81,7 +81,7 @@ The system SHALL provide `FredProvider` for Federal Reserve economic series.
 #### Scenario: Key absent
 - **WHEN** `FRED_API_KEY` is unset and a FRED-backed command is invoked
 - **THEN** the system SHALL exit with code 3 and the message
-  `FRED_API_KEY is not set. Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html then run: qf config set fred_api_key <KEY>`
+  `FRED_API_KEY is not set. Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html then run: sobres config set fred_api_key <KEY>`
 - **AND** SHALL NOT emit a traceback
 
 #### Scenario: Risk-free rate helper
@@ -127,8 +127,8 @@ Docker deployment in 0005 a single mounted volume.
 - **WHEN** no override is configured
 - **THEN** the default backend SHALL be SQLite in the platform user-data dir via
   `platformdirs`
-- **AND** the backend and location SHALL be overridable by `QUANTFOLIO_DB_URL`,
-  which 0005 sets to `sqlite:////data/quantfolio.db`
+- **AND** the backend and location SHALL be overridable by `SOBRES_DB_URL`,
+  which 0005 sets to `sqlite:////data/sobres.db`
 
 #### Scenario: Cache hit
 - **WHEN** an identical request is made within the dataset's TTL
@@ -160,7 +160,7 @@ Docker deployment in 0005 a single mounted volume.
 #### Scenario: Corrupt database
 - **WHEN** the database fails an integrity check on open
 - **THEN** the system SHALL exit with a message naming the file and the
-  `qf db repair` command, and SHALL NOT silently recreate it — the same file
+  `sobres db repair` command, and SHALL NOT silently recreate it — the same file
   holds user-authored state from 0003 onward, so discarding it is data loss
 
 ### Requirement: Data quality is checked on ingest

--- a/openspec/changes/0001-foundation-data-and-cli/specs/observability/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/observability/spec.md
@@ -36,7 +36,7 @@ worse than no logging.
 #### Scenario: Levels
 - **WHEN** verbosity is set
 - **THEN** `-v` SHALL select INFO, `-vv` DEBUG, `--log-level` an explicit level,
-  and `QUANTFOLIO_LOG_LEVEL` the same via environment
+  and `SOBRES_LOG_LEVEL` the same via environment
 - **AND** the default SHALL be WARNING, so ordinary runs are quiet
 
 #### Scenario: Levels mean something specific
@@ -112,7 +112,7 @@ worse than no logging.
 #### Scenario: OpenTelemetry, opt-in
 - **WHEN** tracing is used
 - **THEN** it SHALL use the OpenTelemetry API
-- **AND** the SDK SHALL be an optional install (`quantfolio-cli[otel]`), with the
+- **AND** the SDK SHALL be an optional install (`sobres[otel]`), with the
   API's no-op implementation active by default so an ordinary install carries no
   tracing dependency and no measurable overhead
 

--- a/openspec/changes/0001-foundation-data-and-cli/specs/onboarding/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/onboarding/spec.md
@@ -4,16 +4,16 @@ The user's path is three commands, and each later milestone has to keep it
 three:
 
 ```
-pip install quantfolio-cli
-qf init        # configure everything configurable, interactively
-qf doctor      # prove the install works, or say exactly what is wrong
+pip install sobres
+sobres init        # configure everything configurable, interactively
+sobres doctor      # prove the install works, or say exactly what is wrong
 ```
 
 ## ADDED Requirements
 
 ### Requirement: Settings are declared once
 
-Every configurable value SHALL be one declaration in `quantfolio/settings.py`,
+Every configurable value SHALL be one declaration in `sobres/settings.py`,
 the way every command is one declaration in the registry.
 
 #### Scenario: Declaration shape
@@ -25,8 +25,8 @@ the way every command is one declaration in the registry.
 
 #### Scenario: Four consumers, one source
 - **WHEN** a setting exists in the registry
-- **THEN** `qf init` SHALL prompt for it, `qf doctor` SHALL check it,
-  `qf config set|show` SHALL accept it, and the 0004 settings page SHALL render
+- **THEN** `sobres init` SHALL prompt for it, `sobres doctor` SHALL check it,
+  `sobres config set|show` SHALL accept it, and the 0004 settings page SHALL render
   it, with no per-surface code
 
 #### Scenario: A milestone cannot add an unconfigurable key
@@ -35,16 +35,16 @@ the way every command is one declaration in the registry.
   corresponds to a declared setting
 - **AND** SHALL assert that every declared setting has a doctor check
 
-### Requirement: `qf init`
+### Requirement: `sobres init`
 
 #### Scenario: Guided, in the terminal
-- **WHEN** `qf init` runs in a TTY
+- **WHEN** `sobres init` runs in a TTY
 - **THEN** it SHALL walk the settings registry in order, showing each setting's
   description and where to obtain it, and prompt for a value
 - **AND** secrets SHALL be entered without echo
 
 #### Scenario: Idempotent and re-runnable
-- **WHEN** `qf init` runs against an existing configuration
+- **WHEN** `sobres init` runs against an existing configuration
 - **THEN** it SHALL show each current value — secrets masked to their last four
   characters — and offer to keep or replace it
 - **AND** re-running with no changes SHALL leave the configuration byte-identical
@@ -56,36 +56,36 @@ the way every command is one declaration in the registry.
 
 #### Scenario: Live validation with consent
 - **WHEN** a setting declares a live validator and the user provides a value
-- **THEN** `qf init` SHALL offer to verify it with one request, and report the
+- **THEN** `sobres init` SHALL offer to verify it with one request, and report the
   result
 - **AND** a failed verification SHALL let the user retry, keep the value anyway,
   or skip — never silently store a key that just failed
 
 #### Scenario: Storage is set up
-- **WHEN** `qf init` completes
+- **WHEN** `sobres init` completes
 - **THEN** the database SHALL exist at the resolved URL with migrations applied,
   and the config file SHALL be written at mode `0600`
 - **AND** the paths of both SHALL be printed
 
 #### Scenario: Non-interactive mode
-- **WHEN** `qf init --non-interactive` runs
+- **WHEN** `sobres init --non-interactive` runs
 - **THEN** values SHALL be taken from flags and environment only, with no prompt
 - **AND** a missing required value SHALL exit 3 naming it, so scripts and
   containers fail clearly rather than hang on a prompt
 
 #### Scenario: Ends with proof
-- **WHEN** `qf init` completes
-- **THEN** it SHALL run `qf doctor` and print the result
+- **WHEN** `sobres init` completes
+- **THEN** it SHALL run `sobres doctor` and print the result
 - **AND** SHALL print one runnable first command tailored to what was
   configured, so the next step is a copy-paste rather than a search
 
 #### Scenario: First-run hint
 - **WHEN** any command runs and no configuration exists
-- **THEN** stderr SHALL carry a one-line hint to run `qf init`
+- **THEN** stderr SHALL carry a one-line hint to run `sobres init`
 - **AND** the command SHALL still proceed if it needs nothing that is missing —
   the hint is a hint, not an error
 
-### Requirement: `qf doctor`
+### Requirement: `sobres doctor`
 
 #### Scenario: Checks are declared, like commands and settings
 - **WHEN** a diagnostic exists
@@ -95,8 +95,8 @@ the way every command is one declaration in the registry.
   SHALL register a check for it in the same change
 
 #### Scenario: What is checked in 0001
-- **WHEN** `qf doctor` runs
-- **THEN** it SHALL check at least: Python version; installed quantfolio version
+- **WHEN** `sobres doctor` runs
+- **THEN** it SHALL check at least: Python version; installed sobres version
   and whether a newer release exists; the installer in use; config file presence,
   parseability, and `0600` permissions; every declared setting; database URL
   resolution, reachability, writability, and schema version against the code;
@@ -110,13 +110,13 @@ the way every command is one declaration in the registry.
 - **AND** a check SHALL never report a failure without a next step
 
 #### Scenario: Output
-- **WHEN** `qf doctor` runs in a TTY
+- **WHEN** `sobres doctor` runs in a TTY
 - **THEN** it SHALL render one line per check with a status glyph, grouped by
   category, and a one-line summary
 - **AND** `--format json` SHALL emit the full structured result for scripting
 
 #### Scenario: Exit code
-- **WHEN** `qf doctor` completes
+- **WHEN** `sobres doctor` completes
 - **THEN** it SHALL exit 0 if no check failed, and 1 if any did
 - **AND** warnings SHALL not affect the exit code unless `--strict` is given
 
@@ -127,28 +127,28 @@ the way every command is one declaration in the registry.
   doctor never hangs
 
 #### Scenario: Safe automatic repair
-- **WHEN** `qf doctor --fix` runs
+- **WHEN** `sobres doctor --fix` runs
 - **THEN** every registered fix SHALL be attempted — creating the config
   directory, correcting file permissions, applying pending migrations, clearing a
   corrupt cache entry — and each SHALL be reported as applied or not applicable
 - **AND** no fix SHALL create, change, or delete a secret; those go through
-  `qf init` or `qf config set`
+  `sobres init` or `sobres config set`
 
 #### Scenario: Secrets never appear
-- **WHEN** `qf doctor` reports on a secret setting
+- **WHEN** `sobres doctor` reports on a secret setting
 - **THEN** it SHALL show presence and validity only, never the value, in any
   output format
 
 #### Scenario: One implementation of health
-- **WHEN** 0005's `qf deploy check` or the container `HEALTHCHECK` needs to
+- **WHEN** 0005's `sobres deploy check` or the container `HEALTHCHECK` needs to
   assess the install
 - **THEN** it SHALL run doctor's checks rather than its own
 
-### Requirement: `qf upgrade`
+### Requirement: `sobres upgrade`
 
 #### Scenario: Installer is detected, not assumed
-- **WHEN** `qf upgrade` runs
-- **THEN** it SHALL detect whether quantfolio was installed by pip, pipx, uv, or
+- **WHEN** `sobres upgrade` runs
+- **THEN** it SHALL detect whether sobres was installed by pip, pipx, uv, or
   is running in the container, and SHALL print the exact upgrade command for
   that installer
 
@@ -159,7 +159,7 @@ the way every command is one declaration in the registry.
 
 #### Scenario: Post-upgrade migration
 - **WHEN** an upgrade completes
-- **THEN** the next `qf` invocation SHALL apply any pending migrations per 0003,
+- **THEN** the next `sobres` invocation SHALL apply any pending migrations per 0003,
   after the automatic backup that spec requires
 
 ### Requirement: Onboarding is tested end to end
@@ -167,7 +167,7 @@ the way every command is one declaration in the registry.
 #### Scenario: The three-command path is a test
 - **WHEN** CI's build job runs
 - **THEN** it SHALL install the built wheel into a clean environment, run
-  `qf init --non-interactive`, run `qf doctor --offline`, and assert exit 0
+  `sobres init --non-interactive`, run `sobres doctor --offline`, and assert exit 0
 - **AND** it SHALL then run one data command against a recorded fixture and
   assert output
 

--- a/openspec/changes/0001-foundation-data-and-cli/specs/storage/spec.md
+++ b/openspec/changes/0001-foundation-data-and-cli/specs/storage/spec.md
@@ -7,8 +7,8 @@ it, not the interface itself.
 
 ### Requirement: Storage port
 
-All persistence SHALL go through protocols in `quantfolio.data.storage.base`.
-No module outside `quantfolio.data.storage.adapters` SHALL import a database
+All persistence SHALL go through protocols in `sobres.data.storage.base`.
+No module outside `sobres.data.storage.adapters` SHALL import a database
 driver.
 
 #### Scenario: Drivers are confined to adapters
@@ -25,8 +25,8 @@ driver.
 
 #### Scenario: Backend selection is configuration
 - **WHEN** the storage backend is chosen
-- **THEN** it SHALL come from a URL in configuration (`QUANTFOLIO_DB_URL`),
-  defaulting to `sqlite:///<user-data-dir>/quantfolio.db`
+- **THEN** it SHALL come from a URL in configuration (`SOBRES_DB_URL`),
+  defaulting to `sqlite:///<user-data-dir>/sobres.db`
 - **AND** switching backends SHALL require no change to any call site
 
 #### Scenario: Unknown backend
@@ -111,7 +111,7 @@ and DuckDB — the named candidate backends.
 
 #### Scenario: Errors are translated
 - **WHEN** a backend raises a driver-specific exception
-- **THEN** the adapter SHALL translate it into quantfolio's own error taxonomy
+- **THEN** the adapter SHALL translate it into sobres's own error taxonomy
 - **AND** no driver exception SHALL escape `data/storage/adapters/`
 
 #### Scenario: Contention
@@ -122,7 +122,7 @@ and DuckDB — the named candidate backends.
 ### Requirement: SQLite as the default adapter
 
 #### Scenario: Default backend
-- **WHEN** no `QUANTFOLIO_DB_URL` is configured
+- **WHEN** no `SOBRES_DB_URL` is configured
 - **THEN** SQLite SHALL be used, requiring no server and no additional install
 
 #### Scenario: SQLite-specific tuning stays in its adapter

--- a/openspec/changes/0001-foundation-data-and-cli/tasks.md
+++ b/openspec/changes/0001-foundation-data-and-cli/tasks.md
@@ -19,7 +19,7 @@ Estimates are focused hours. Each task names the test that proves it.
         `::test_non_tty_defaults_to_csv`
 - [ ] **A3b. Command registry** (3h)
       `registry.py`: `Command`, `register`, shared parameter types (`TickerList`,
-      `Frequency`, `Weights`, `Currency`), the Typer generator, `qf commands`.
+      `Frequency`, `Weights`, `Currency`), the Typer generator, `sobres commands`.
       → `tests/cli/test_registry.py::test_typer_app_has_one_subcommand_per_registration`,
         `::test_defaults_come_only_from_param_model`,
         `::test_cross_field_validator_rejects_weight_count_mismatch`,
@@ -59,7 +59,7 @@ Estimates are focused hours. Each task names the test that proves it.
 
 - [ ] **B0. Storage port** (3h)
       `data/storage/base.py`: `ObservationStore` / `KeyValueStore` protocols
-      phrased in domain terms, the backend registry, and `QUANTFOLIO_DB_URL`
+      phrased in domain terms, the backend registry, and `SOBRES_DB_URL`
       resolution.
       → `tests/data/test_storage_port.py::test_unknown_url_scheme_exits_3_listing_backends`
       → `tests/test_architecture.py::test_db_drivers_imported_only_in_adapters`
@@ -149,25 +149,25 @@ Estimates are focused hours. Each task names the test that proves it.
 
 - [ ] **C1. Root app and error boundary** (1.5h)
       `cli/main.py`: `--version`, `--debug`, `--format`, `--refresh`, `-v/-vv`,
-      `--log-level`, `--log-format`; a single handler mapping `QuantfolioError` →
+      `--log-level`, `--log-format`; a single handler mapping `SobresError` →
       message + exit code, with the run id in the message.
       → `tests/cli/test_main.py::test_version`, `::test_bare_shows_help_exit_0`,
         `::test_provider_error_exits_4_without_traceback`
-- [ ] **C2. `qf data` group** (2h) — `prices`, `macro`, `factors`, `fx`, each a
+- [ ] **C2. `sobres data` group** (2h) — `prices`, `macro`, `factors`, `fx`, each a
       registry declaration; no hand-written Typer command.
       → `tests/cli/test_data_commands.py` (one test per subcommand × 3 formats)
-- [ ] **C3. `qf cache` group** (1h) — `info`, `clear` (with confirm + `--yes`).
-      Cache-only; the wider `qf db` group arrives with 0003.
+- [ ] **C3. `sobres cache` group** (1h) — `info`, `clear` (with confirm + `--yes`).
+      Cache-only; the wider `sobres db` group arrives with 0003.
       → `tests/cli/test_cache_commands.py::test_clear_requires_confirmation`
-- [ ] **C4. `qf config` group** (1h) — `set`, `show` (masked), `path`.
+- [ ] **C4. `sobres config` group** (1h) — `set`, `show` (masked), `path`.
       → `tests/cli/test_config_commands.py::test_show_masks_api_keys`
 - [ ] **C4b. Settings registry** (2h)
       `settings.py`: `@setting` declarations with env, secret, required,
-      description, obtain, optional live validator; `qf config set|show`
+      description, obtain, optional live validator; `sobres config set|show`
       re-pointed at it.
       → `tests/cli/test_settings.py::test_every_env_var_read_is_a_declared_setting`,
         `::test_config_show_masks_secrets_to_last_four`
-- [ ] **C4c. `qf init`** (3h)
+- [ ] **C4c. `sobres init`** (3h)
       Rich-prompt wizard over the registry; no-echo secrets; idempotent re-run
       showing masked current values; live validation with consent;
       `--non-interactive`; sets up storage; ends by running doctor and printing
@@ -176,7 +176,7 @@ Estimates are focused hours. Each task names the test that proves it.
         `::test_non_interactive_missing_required_exits_3_naming_it`,
         `::test_failed_live_validation_never_stores_silently`,
         `::test_ends_by_running_doctor`
-- [ ] **C4d. `qf doctor`** (3h)
+- [ ] **C4d. `sobres doctor`** (3h)
       `Check` registry with `run` and optional `fix`; the 0001 check set;
       grouped TTY rendering and `--format json`; exit 0/1 with `--strict`;
       `--offline`; 5s network caps; `--fix` never touches secrets.
@@ -185,7 +185,7 @@ Estimates are focused hours. Each task names the test that proves it.
         `::test_offline_skips_rather_than_fails`,
         `::test_fix_never_writes_a_secret`,
         `::test_warnings_do_not_change_exit_code_without_strict`
-- [ ] **C4e. `qf upgrade`** (1h)
+- [ ] **C4e. `sobres upgrade`** (1h)
       Installer detection (pip / pipx / uv / container); exact command;
       confirmation; `--check`.
       → `tests/cli/test_upgrade.py::test_detects_installer_and_prints_matching_command`
@@ -197,11 +197,11 @@ Estimates are focused hours. Each task names the test that proves it.
 - [ ] **D1. Fixture recording script** (1h)
       `scripts/record_fixtures.py` — regenerates `tests/fixtures/` deliberately, so
       re-recording is a reviewable diff rather than an ad-hoc action.
-- [ ] **D2. README quickstart** (1h) — install, the three `qf data` commands, the
+- [ ] **D2. README quickstart** (1h) — install, the three `sobres data` commands, the
       no-key promise, and the not-advice disclaimer.
 - [ ] **D3. CI green** (1.5h) — ruff, ruff format, mypy --strict, pytest; the
-      build job's clean-venv smoke extended to `qf init --non-interactive` →
-      `qf doctor --offline` → one data command on a fixture.
+      build job's clean-venv smoke extended to `sobres init --non-interactive` →
+      `sobres doctor --offline` → one data command on a fixture.
 - [ ] **D4. Port reuse audit** (1h)
       Diff `NewsWaveMetrics/fetch_yfinance.py` and `extract_economic_data.py` against
       B4/B5; lift anything that handles a real-world edge case these specs missed.
@@ -218,7 +218,7 @@ real unknowns.
 
 ## Definition of done
 
-- [ ] `pip install quantfolio-cli` with no keys → `qf data prices AAPL` works
+- [ ] `pip install sobres` with no keys → `sobres data prices AAPL` works
 - [ ] No database driver is imported outside `data/storage/adapters/`
 - [ ] The conformance suite passes against the SQLite adapter
 - [ ] `core/` imports no logging, tracing, network, or database module
@@ -226,11 +226,11 @@ real unknowns.
 - [ ] stdout is byte-identical across log levels and with tracing on and off
 - [ ] No call site outside `data/currency.py` multiplies or divides by a rate
 - [ ] A single-currency run fetches no rates and matches a no-conversion build
-- [ ] `pip install` → `qf init --non-interactive` → `qf doctor --offline` exits 0 in a clean venv, in CI
+- [ ] `pip install` → `sobres init --non-interactive` → `sobres doctor --offline` exits 0 in a clean venv, in CI
 - [ ] Every env var the code reads is a declared setting; every setting and provider has a doctor check
 - [ ] No Typer command exists that is not a registry declaration
 - [ ] `tests/architecture/` and `tests/invariants/` run against every registered command
 - [ ] `pytest -m "not network"` passes with networking disabled
 - [ ] `mypy --strict` clean
 - [ ] Every scenario in both spec deltas has a test that references it
-- [ ] A second identical `qf data prices` call is served from cache in < 1s
+- [ ] A second identical `sobres data prices` call is served from cache in < 1s

--- a/openspec/changes/0002-portfolio-optimization/design.md
+++ b/openspec/changes/0002-portfolio-optimization/design.md
@@ -28,9 +28,9 @@ Three design responses, all in v1:
 
 1. **Shrinkage by default.** Ledoit-Wolf is the default covariance estimator, not an
    option a user has to discover. Sample covariance remains available and explicit.
-2. **The frontier, not the point.** `qf optimize frontier` shows the whole trade-off
+2. **The frontier, not the point.** `sobres optimize frontier` shows the whole trade-off
    curve. A single "optimal" portfolio invites false precision; a curve does not.
-3. **Walk-forward truth.** `qf optimize backtest` re-solves at each rebalance using
+3. **Walk-forward truth.** `sobres optimize backtest` re-solves at each rebalance using
    only prior data. The gap between the in-sample Sharpe and the walk-forward Sharpe
    is the most useful number this tool produces, and it ships in v1.
 
@@ -53,7 +53,7 @@ objective), and it is already a base dependency via `scipy`.
   `w_i * (Σw)_i / (wᵀΣw)` from `1/n`.
 - `equal_weight` — no solver.
 
-`cvxpy` stays an **opt-in extra** (`pip install quantfolio[opt]`). It is the right
+`cvxpy` stays an **opt-in extra** (`pip install sobres[opt]`). It is the right
 tool for convex objectives that SLSQP handles badly (CVaR, cardinality, robust
 formulations) — all post-v1. Making it a base dependency would drag a solver stack
 into an install that does not need it.

--- a/openspec/changes/0002-portfolio-optimization/proposal.md
+++ b/openspec/changes/0002-portfolio-optimization/proposal.md
@@ -10,12 +10,12 @@ status: proposed
 ## Outcome
 
 ```bash
-qf optimize markowitz --tickers AAPL MSFT NVDA JNJ XOM GLD \
+sobres optimize markowitz --tickers AAPL MSFT NVDA JNJ XOM GLD \
     --start 2015-01-01 --objective max-sharpe --max-weight 0.35
 
-qf optimize frontier --tickers ... --points 50 --format csv > frontier.csv
+sobres optimize frontier --tickers ... --points 50 --format csv > frontier.csv
 
-qf optimize backtest --tickers ... --objective max-sharpe \
+sobres optimize backtest --tickers ... --objective max-sharpe \
     --rebalance quarterly --lookback 36m --start 2015-01-01
 ```
 
@@ -33,7 +33,7 @@ base.
 The backtest ships **with** the optimizer, not after it, and that is deliberate.
 In-sample mean-variance optimization produces beautiful, useless numbers: it
 maximizes a Sharpe ratio on data it has already seen. Shipping the optimizer alone
-would make the tool's flagship output actively misleading. `qf optimize backtest` is
+would make the tool's flagship output actively misleading. `sobres optimize backtest` is
 the honesty mechanism, so it is part of v1's definition of done.
 
 ## What changes
@@ -47,7 +47,7 @@ the honesty mechanism, so it is part of v1's definition of done.
   - `core/optimize.py` — min-variance, max-Sharpe, target-return/target-risk,
     risk parity, equal weight; the efficient frontier
   - `core/backtest.py` — walk-forward rebalancing with transaction costs
-- **New CLI group `qf optimize`** — `markowitz`, `frontier`, `backtest`, `risk`.
+- **New CLI group `sobres optimize`** — `markowitz`, `frontier`, `backtest`, `risk`.
 - Port this repository's own prior implementation
   (`legacy_code/Financial Portfolio Optimization.R`) to `core/optimize.py`, with its
   results as regression fixtures.

--- a/openspec/changes/0002-portfolio-optimization/specs/portfolio-optimization/spec.md
+++ b/openspec/changes/0002-portfolio-optimization/specs/portfolio-optimization/spec.md
@@ -217,26 +217,26 @@ The system SHALL evaluate an optimization strategy out-of-sample.
 - **THEN** the backtest SHALL start at the first date that does have it, and report
   the actual start on stderr
 
-### Requirement: `qf optimize` command group
+### Requirement: `sobres optimize` command group
 
 #### Scenario: Markowitz
-- **WHEN** `qf optimize markowitz --tickers AAPL MSFT --start 2015-01-01` runs
+- **WHEN** `sobres optimize markowitz --tickers AAPL MSFT --start 2015-01-01` runs
 - **THEN** a weights table SHALL print with the portfolio's expected return,
   volatility, and Sharpe
 - **AND** the estimators used SHALL be named in the output header
 
 #### Scenario: Frontier
-- **WHEN** `qf optimize frontier --tickers ... --points 50 --format csv` runs
+- **WHEN** `sobres optimize frontier --tickers ... --points 50 --format csv` runs
 - **THEN** CSV with one row per frontier point SHALL print, columns
   `ret, vol, sharpe, <one per ticker>`
 
 #### Scenario: Backtest
-- **WHEN** `qf optimize backtest ... --rebalance quarterly` runs
+- **WHEN** `sobres optimize backtest ... --rebalance quarterly` runs
 - **THEN** the strategy and benchmark panels SHALL print side by side
 - **AND** the output SHALL state the out-of-sample window and total costs paid
 
 #### Scenario: Risk panel of a given portfolio
-- **WHEN** `qf optimize risk --tickers AAPL MSFT --weights 0.6 0.4` runs
+- **WHEN** `sobres optimize risk --tickers AAPL MSFT --weights 0.6 0.4` runs
 - **THEN** the full risk panel for that fixed portfolio SHALL print
 
 #### Scenario: Weights supplied must be valid

--- a/openspec/changes/0002-portfolio-optimization/tasks.md
+++ b/openspec/changes/0002-portfolio-optimization/tasks.md
@@ -81,13 +81,13 @@ Depends on 0001. Estimates are focused hours.
 
 ## Wave E — CLI (C, D first)
 
-- [ ] **E1. `qf optimize markowitz`** (2h) — estimator provenance in the header.
+- [ ] **E1. `sobres optimize markowitz`** (2h) — estimator provenance in the header.
       → `tests/cli/test_optimize.py::test_header_names_estimators`
-- [ ] **E2. `qf optimize frontier`** (1.5h)
+- [ ] **E2. `sobres optimize frontier`** (1.5h)
       → `::test_csv_columns_are_ret_vol_sharpe_then_tickers`
-- [ ] **E3. `qf optimize backtest`** (2h) — side-by-side panels, OOS window, costs.
+- [ ] **E3. `sobres optimize backtest`** (2h) — side-by-side panels, OOS window, costs.
       → `::test_output_states_oos_window_and_costs`
-- [ ] **E4. `qf optimize risk`** (1h) — fixed weights, full panel.
+- [ ] **E4. `sobres optimize risk`** (1h) — fixed weights, full panel.
       → `::test_weights_must_match_ticker_count_and_sum_to_one`
 
 ## Wave F — validation and release
@@ -101,14 +101,14 @@ Depends on 0001. Estimates are focused hours.
       → `tests/test_textbook_cases.py`
 - [ ] **F3. Docs: "Why your backtest looks too good"** (2h)
       Plain-language page on estimation error, in-sample vs. walk-forward, and how
-      to read the gap. Linked from `qf optimize backtest` output.
+      to read the gap. Linked from `sobres optimize backtest` output.
 - [ ] **F4. README + `v1.0.0`** (2h) — worked example with real output; tag; PyPI.
 
 **Total: ~48h.** Critical path: B2 → B3 → C2 → C3 → C7 → D1 → E3.
 
 ## Definition of done
 
-- [ ] All four `qf optimize` subcommands work end to end on live data
+- [ ] All four `sobres optimize` subcommands work end to end on live data
 - [ ] The no-lookahead test passes (D1)
 - [ ] Weights match the R reference within `1e-4` (F1)
 - [ ] Max-Sharpe matches the closed-form tangency portfolio within `1e-6` (C3)

--- a/openspec/changes/0003-local-persistence/proposal.md
+++ b/openspec/changes/0003-local-persistence/proposal.md
@@ -13,12 +13,12 @@ Work stops being disposable. Portfolios, watchlists, goals and every analysis ru
 are saved and recallable, from the CLI now and from the UI in 0004:
 
 ```bash
-qf portfolio save core --tickers AAPL MSFT NVDA JNJ --weights 0.3 0.3 0.2 0.2
-qf optimize markowitz --portfolio core --save-run
-qf run list --limit 20
-qf run show 42 --format json
-qf db info
-qf db export --to ~/backups/quantfolio-2026-09-12.sqlite
+sobres portfolio save core --tickers AAPL MSFT NVDA JNJ --weights 0.3 0.3 0.2 0.2
+sobres optimize markowitz --portfolio core --save-run
+sobres run list --limit 20
+sobres run show 42 --format json
+sobres db info
+sobres db export --to ~/backups/sobres-2026-09-12.sqlite
 ```
 
 ## Why
@@ -46,7 +46,7 @@ cache into a database: schema versioning, migrations, and the application tables
   data out; no math, and no driver import outside the adapters.
 - The conformance suite from 0001 grows to cover the new repositories, so a
   future backend is still proven by one shared suite rather than by inspection.
-- **New CLI groups** `qf portfolio`, `qf watchlist`, `qf run`, and `qf db`.
+- **New CLI groups** `sobres portfolio`, `sobres watchlist`, `sobres run`, and `sobres db`.
 - `--save-run` on the analytical commands; `--portfolio <name>` accepted wherever
   `--tickers` is, so saved state substitutes for typing.
 
@@ -74,9 +74,9 @@ cache into a database: schema versioning, migrations, and the application tables
 
 | Risk | Mitigation |
 |---|---|
-| A migration corrupts real user data | Forward-only, tested against fixture databases at every prior schema version; automatic timestamped backup before any migration; `qf db export` for a manual copy first |
+| A migration corrupts real user data | Forward-only, tested against fixture databases at every prior schema version; automatic timestamped backup before any migration; `sobres db export` for a manual copy first |
 | Schema churn during 0004 and 0005 makes migrations painful early | Version from the first release; treat every shipped schema as immutable even pre-1.0, since the cost of the discipline is far below the cost of a user's lost portfolios |
 | CLI and server write concurrently and one wedges | WAL plus a busy timeout from 0001; writes are short transactions; the job table is the only hot row and is written by a single worker |
-| The database grows without bound as price history accumulates | `qf db info` reports size by table; `qf cache clear` prunes cached observations while leaving user-authored rows untouched — the two must never be conflated |
+| The database grows without bound as price history accumulates | `sobres db info` reports size by table; `sobres cache clear` prunes cached observations while leaving user-authored rows untouched — the two must never be conflated |
 | Repositories accrete SQLite-shaped assumptions now that there is real application state | Every repository is added to the shared conformance suite as it is written, and the portability guards from 0001 (portable types, application-generated ids, explicit UTC, JSON as text) apply to every new table |
 | Saved runs reference market data that later gets revised | A run records the inputs and the resolved parameters it used, so it stays interpretable; it is a record of an analysis, not a promise of reproducibility against a mutable index |

--- a/openspec/changes/0003-local-persistence/specs/persistence/spec.md
+++ b/openspec/changes/0003-local-persistence/specs/persistence/spec.md
@@ -18,7 +18,7 @@ The database SHALL carry a schema version and upgrade itself on open.
 
 #### Scenario: Newer database than the installed tool
 - **WHEN** the database's schema version is higher than the running code knows
-- **THEN** the system SHALL exit 3 telling the user to upgrade quantfolio
+- **THEN** the system SHALL exit 3 telling the user to upgrade sobres
 - **AND** SHALL NOT open the database, downgrade it, or write to it
 
 #### Scenario: Migrations are tested against real prior states
@@ -34,7 +34,7 @@ The database SHALL carry a schema version and upgrade itself on open.
 ### Requirement: Saved portfolios
 
 #### Scenario: Save
-- **WHEN** `qf portfolio save core --tickers AAPL MSFT --weights 0.6 0.4` runs
+- **WHEN** `sobres portfolio save core --tickers AAPL MSFT --weights 0.6 0.4` runs
 - **THEN** the portfolio SHALL persist under that name with its holdings
 - **AND** weights SHALL be validated as in 0002 before anything is written
 
@@ -53,14 +53,14 @@ The database SHALL carry a schema version and upgrade itself on open.
 - **THEN** the system SHALL refuse and say which name is taken
 
 #### Scenario: Listing and deletion
-- **WHEN** `qf portfolio list` runs
+- **WHEN** `sobres portfolio list` runs
 - **THEN** each portfolio's name, holding count, and last-modified time SHALL print
-- **AND** `qf portfolio delete <name>` SHALL require confirmation unless `--yes`
+- **AND** `sobres portfolio delete <name>` SHALL require confirmation unless `--yes`
 
 ### Requirement: Watchlists and goals
 
 #### Scenario: Watchlist
-- **WHEN** `qf watchlist add tech NVDA AMD` runs
+- **WHEN** `sobres watchlist add tech NVDA AMD` runs
 - **THEN** those symbols SHALL be added to the named watchlist, creating it if absent
 - **AND** adding a symbol already present SHALL be a no-op, not an error
 
@@ -84,12 +84,12 @@ The database SHALL carry a schema version and upgrade itself on open.
 - **AND** a run recorded today SHALL remain interpretable after a default changes
 
 #### Scenario: Inspecting runs
-- **WHEN** `qf run list` runs
+- **WHEN** `sobres run list` runs
 - **THEN** id, command, timestamp, and a one-line result summary SHALL print
-- **AND** `qf run show <id> --format json` SHALL emit the complete stored record
+- **AND** `sobres run show <id> --format json` SHALL emit the complete stored record
 
 #### Scenario: Comparing runs
-- **WHEN** `qf run diff <id-a> <id-b>` runs on two runs of the same command
+- **WHEN** `sobres run diff <id-a> <id-b>` runs on two runs of the same command
 - **THEN** parameter and result differences SHALL be shown side by side
 - **AND** comparing runs of different commands SHALL raise `UsageError`
 
@@ -101,17 +101,17 @@ The database SHALL carry a schema version and upgrade itself on open.
 ### Requirement: Database administration
 
 #### Scenario: Inspect
-- **WHEN** `qf db info` runs
+- **WHEN** `sobres db info` runs
 - **THEN** the file path, schema version, total size, and per-table row counts and
   sizes SHALL print
 
 #### Scenario: Export
-- **WHEN** `qf db export --to <path>` runs
+- **WHEN** `sobres db export --to <path>` runs
 - **THEN** a consistent copy SHALL be written using SQLite's backup API, safe to
   run while the database is in use
 
 #### Scenario: Cache and user data are never conflated
-- **WHEN** `qf cache clear` runs
+- **WHEN** `sobres cache clear` runs
 - **THEN** only cached provider observations SHALL be removed
 - **AND** portfolios, watchlists, goals and runs SHALL be untouched
 - **AND** the command SHALL report what it removed and what it preserved
@@ -121,7 +121,7 @@ The database SHALL carry a schema version and upgrade itself on open.
 - **THEN** it SHALL prompt for confirmation, with `--yes` for scripted use
 
 #### Scenario: Repair
-- **WHEN** `qf db repair` runs on a database failing its integrity check
+- **WHEN** `sobres db repair` runs on a database failing its integrity check
 - **THEN** the system SHALL attempt recovery into a new file, leaving the original
   in place, and report what was and was not recovered
 
@@ -144,7 +144,7 @@ The database SHALL carry a schema version and upgrade itself on open.
   identifiers, explicit UTC timestamps, and JSON encoded as text
 
 #### Scenario: Switching backends is configuration
-- **WHEN** `QUANTFOLIO_DB_URL` names a different registered backend
+- **WHEN** `SOBRES_DB_URL` names a different registered backend
 - **THEN** every command in this change SHALL behave identically
 - **AND** no module outside `data/storage/adapters/` SHALL require modification
 
@@ -153,7 +153,7 @@ The database SHALL carry a schema version and upgrade itself on open.
 #### Scenario: Repositories perform no computation
 - **WHEN** any module under `data/storage/` is reviewed
 - **THEN** it SHALL contain persistence logic only
-- **AND** SHALL NOT import from `quantfolio.core`
+- **AND** SHALL NOT import from `sobres.core`
 
 #### Scenario: Core remains I/O-free
 - **WHEN** any module under `core/` is reviewed
@@ -179,7 +179,7 @@ The database SHALL carry a schema version and upgrade itself on open.
 
 #### Scenario: One file is the whole state
 - **WHEN** the database file is copied to another machine and
-  `QUANTFOLIO_DB_URL` points at it
+  `SOBRES_DB_URL` points at it
 - **THEN** every saved portfolio, watchlist, goal, run and cached observation
   SHALL be available there
 

--- a/openspec/changes/0004-web-ui/design.md
+++ b/openspec/changes/0004-web-ui/design.md
@@ -24,7 +24,7 @@ handler)`. From that:
 
 | Surface | Generated | Mechanism |
 |---|---|---|
-| CLI | `qf <group> <name> --field ...` | Typer options from `params.model_fields` |
+| CLI | `sobres <group> <name> --field ...` | Typer options from `params.model_fields` |
 | API | `POST /api/v1/<group>/<name>` | FastAPI route with `params` as the body model |
 | OpenAPI | schema entry | FastAPI, for free |
 | UI | form + result view | TypeScript types generated from OpenAPI; a form renderer keyed on field type |
@@ -77,10 +77,10 @@ update. `core/` still emits nothing itself.
 SSE over websockets: one direction is all that is needed, it works through every
 proxy, and reconnection is a browser primitive rather than a protocol to write.
 
-## `qf open`: terminal to browser in one command
+## `sobres open`: terminal to browser in one command
 
 ```
-qf open [target]
+sobres open [target]
    │
    ├─ server answering on the port and it is ours?  → launch browser, exit 0
    ├─ something else on the port?                    → error, suggest --port
@@ -99,9 +99,9 @@ it. Printing a URL is never an error; the command's job is to get the user to
 the app, and the URL is the app.
 
 Targets map to the frontend view manifest — the same file the parity test
-reads — so `qf open` can reach exactly the views that exist and rejects
-others with the list. `qf init --web` is `qf open settings`; `qf serve --open`
-is `qf serve` plus the launch. One mechanism, three entry points.
+reads — so `sobres open` can reach exactly the views that exist and rejects
+others with the list. `sobres init --web` is `sobres open settings`; `sobres serve --open`
+is `sobres serve` plus the launch. One mechanism, three entry points.
 
 ## Access model
 
@@ -132,11 +132,11 @@ frontend/
 └── manifest.json      # registry names this build renders — read by the parity test
 ```
 
-Built assets are copied into the wheel at `quantfolio/api/static/` by the
-release pipeline. `pip install quantfolio-cli[web]` therefore needs no Node; only
+Built assets are copied into the wheel at `sobres/api/static/` by the
+release pipeline. `pip install sobres[web]` therefore needs no Node; only
 a contributor changing `frontend/` does.
 
-**The equivalent command is always shown.** Every form renders the `qf` command
+**The equivalent command is always shown.** Every form renders the `sobres` command
 line it would run, live. The UI is a way of learning the CLI, not a replacement
 for it — and it keeps the two surfaces honest with each other in the user's eyes,
 not just in the test suite.
@@ -151,6 +151,6 @@ not just in the test suite.
 | Single in-process worker | Worker pool, Celery, RQ | Single-user process; one worker answers every concurrency question by construction |
 | SSE | WebSockets | One direction suffices; proxies and reconnection are solved problems |
 | Deployment token | User accounts | Multi-user is out of scope; a fake account model is debt |
-| `qf open` targets from the view manifest | A hand-maintained target list | The manifest already exists for parity; a second list would drift from it |
+| `sobres open` targets from the view manifest | A hand-maintained target list | The manifest already exists for parity; a second list would drift from it |
 | Headless prints the URL and exits 0 | Error when no browser | The URL *is* the app; failing to launch a browser is not failing the user |
 | Frontend manifest for parity | Trusting the view list | Parity must fail Python CI, where the registry is |

--- a/openspec/changes/0004-web-ui/proposal.md
+++ b/openspec/changes/0004-web-ui/proposal.md
@@ -11,10 +11,10 @@ planning_depth: proposal + 2 spec deltas + design (tasks written when 0003 lands
 ## Outcome
 
 ```bash
-qf open                       # starts the server if needed, opens the browser
-qf open doctor                # straight to a view: settings, doctor, runs, run 42, ...
-qf serve                      # http://127.0.0.1:8787, no browser
-qf serve --host 0.0.0.0 --port 8787   # prints a token; required to bind non-local
+sobres open                       # starts the server if needed, opens the browser
+sobres open doctor                # straight to a view: settings, doctor, runs, run 42, ...
+sobres serve                      # http://127.0.0.1:8787, no browser
+sobres serve --host 0.0.0.0 --port 8787   # prints a token; required to bind non-local
 ```
 
 A dark, fast single-page app with **every CLI capability** behind a form: pick or
@@ -36,7 +36,7 @@ show, and "watch the frontier solve" is the demo.
 
 ## What changes
 
-- **New capability `http-api`** — FastAPI app at `quantfolio/api/`, a thin adapter
+- **New capability `http-api`** — FastAPI app at `sobres/api/`, a thin adapter
   over `core` and `data` exactly like `cli/`, holding no business logic.
 - **New capability `web-ui`** — React + TypeScript SPA under `frontend/`, built to
   static assets and served by the same process.
@@ -50,7 +50,7 @@ show, and "watch the frontier solve" is the demo.
 - **Job execution** — optimizations and backtests run as jobs persisted through
   0003's repositories, with progress streamed over SSE. Trace context and run id
   are persisted with the job, so work that outlives its request stays traceable.
-- `qf serve` as the entry point and `qf open` as the one-command path from
+- `sobres serve` as the entry point and `sobres open` as the one-command path from
   terminal to browser; `[web]` extra for FastAPI and uvicorn.
 
 ## The parity problem, and how it is solved

--- a/openspec/changes/0004-web-ui/specs/http-api/spec.md
+++ b/openspec/changes/0004-web-ui/specs/http-api/spec.md
@@ -9,7 +9,7 @@ consumers of those declarations and changes nothing about how a command is
 declared.
 
 #### Scenario: One declaration, three surfaces
-- **WHEN** a command exists in `quantfolio/registry.py` per 0001
+- **WHEN** a command exists in `sobres/registry.py` per 0001
 - **THEN** an HTTP route, an OpenAPI schema entry, and a UI form SHALL all exist
   for it without further code
 
@@ -80,7 +80,7 @@ declared.
 ### Requirement: Access control
 
 #### Scenario: Loopback by default
-- **WHEN** `qf serve` runs with no `--host`
+- **WHEN** `sobres serve` runs with no `--host`
 - **THEN** it SHALL bind `127.0.0.1` only
 - **AND** no token SHALL be required, since the socket is not reachable remotely
 
@@ -106,7 +106,7 @@ declared.
 - **THEN** the response SHALL be 401 with no detail about what was wrong
 
 #### Scenario: Rotation and revocation
-- **WHEN** `qf serve token rotate` runs
+- **WHEN** `sobres serve token rotate` runs
 - **THEN** a new token SHALL replace the old one and every existing session SHALL
   stop working
 

--- a/openspec/changes/0004-web-ui/specs/web-ui/spec.md
+++ b/openspec/changes/0004-web-ui/specs/web-ui/spec.md
@@ -20,9 +20,9 @@
   silently break the UI
 
 #### Scenario: No Node needed to install the tool
-- **WHEN** a user runs `pip install quantfolio-cli[web]`
+- **WHEN** a user runs `pip install sobres[web]`
 - **THEN** pre-built static assets SHALL be included in the wheel
-- **AND** `qf serve` SHALL work with no Node toolchain present
+- **AND** `sobres serve` SHALL work with no Node toolchain present
 
 ### Requirement: Every CLI capability has a view
 
@@ -44,7 +44,7 @@
 
 #### Scenario: The equivalent command is always shown
 - **WHEN** a form is filled in
-- **THEN** the equivalent `qf` command line SHALL be displayed and copyable
+- **THEN** the equivalent `sobres` command line SHALL be displayed and copyable
 - **AND** it SHALL update live as fields change, so the UI teaches the CLI rather
   than replacing it
 
@@ -55,31 +55,31 @@
 - **THEN** every setting declared in 0001's settings registry SHALL appear as a
   field, with its description and how-to-obtain link, secrets masked and never
   echoed back
-- **AND** saving SHALL write through the same code path as `qf config set`
+- **AND** saving SHALL write through the same code path as `sobres config set`
 
 #### Scenario: Live validation in the browser
 - **WHEN** a setting with a live validator is saved
 - **THEN** the UI SHALL offer to verify it and show the result, mirroring
-  `qf init`
+  `sobres init`
 
 #### Scenario: Doctor has a view
 - **WHEN** the health view renders
-- **THEN** it SHALL show `qf doctor`'s checks with the same statuses, messages,
+- **THEN** it SHALL show `sobres doctor`'s checks with the same statuses, messages,
   and next steps, from the same check registry
 - **AND** a check with a registered fix SHALL offer to run it, never touching a
   secret
 
-#### Scenario: `qf init --web`
-- **WHEN** `qf init --web` runs once this change has landed
-- **THEN** it SHALL behave as `qf open settings`, the browser form of the same
+#### Scenario: `sobres init --web`
+- **WHEN** `sobres init --web` runs once this change has landed
+- **THEN** it SHALL behave as `sobres open settings`, the browser form of the same
   wizard
 
 ### Requirement: Launching the UI from the CLI
 
 The browser is one command away from the terminal, and never the only way in.
 
-#### Scenario: `qf open`
-- **WHEN** `qf open` runs and no server is listening on the configured port
+#### Scenario: `sobres open`
+- **WHEN** `sobres open` runs and no server is listening on the configured port
 - **THEN** it SHALL start the server bound to loopback, wait for the health
   endpoint to pass, open the default browser to the app, and keep serving until
   interrupted
@@ -87,14 +87,14 @@ The browser is one command away from the terminal, and never the only way in.
   it is available even if the launch fails
 
 #### Scenario: Server already running
-- **WHEN** `qf open` runs and a quantfolio server already answers on the port
+- **WHEN** `sobres open` runs and a sobres server already answers on the port
 - **THEN** it SHALL open the browser to that server and exit 0 without starting
   a second one
-- **AND** a non-quantfolio process on the port SHALL produce an error naming the
+- **AND** a non-sobres process on the port SHALL produce an error naming the
   port and suggesting `--port`
 
 #### Scenario: Targets
-- **WHEN** `qf open <target>` runs
+- **WHEN** `sobres open <target>` runs
 - **THEN** `target` SHALL accept `settings`, `doctor`, `runs`, `run <id>`,
   `portfolio <name>`, and any registry command name, opening that view directly
 - **AND** the accepted set SHALL be derived from the frontend view manifest, so
@@ -104,7 +104,7 @@ The browser is one command away from the terminal, and never the only way in.
 #### Scenario: Headless is not an error
 - **WHEN** no browser can be launched — no display, an SSH session, or inside
   the container
-- **THEN** `qf open` SHALL print the URL and exit 0
+- **THEN** `sobres open` SHALL print the URL and exit 0
 - **AND** `--print-url` SHALL force that behavior anywhere
 
 #### Scenario: Browser choice is respected
@@ -113,12 +113,12 @@ The browser is one command away from the terminal, and never the only way in.
 
 #### Scenario: Never a token in the URL
 - **WHEN** the server requires a token
-- **THEN** `qf open` SHALL open the app's entry page and the user SHALL paste the
+- **THEN** `sobres open` SHALL open the app's entry page and the user SHALL paste the
   token once there, per `http-api`; the token SHALL NOT be placed in the URL
 
-#### Scenario: `qf serve --open`
-- **WHEN** `qf serve --open` runs
-- **THEN** it SHALL behave as `qf serve` followed by the browser launch above,
+#### Scenario: `sobres serve --open`
+- **WHEN** `sobres serve --open` runs
+- **THEN** it SHALL behave as `sobres serve` followed by the browser launch above,
   once healthy
 
 ### Requirement: Dark mode

--- a/openspec/changes/0005-docker-distribution/proposal.md
+++ b/openspec/changes/0005-docker-distribution/proposal.md
@@ -47,8 +47,10 @@ config resolution chain the CLI already uses keeps those the same thing.
   wheel, and a slim runtime stage carries neither toolchain.
 - `docker-compose.yml`, `.dockerignore`.
 - **New CLI group `sobres deploy`** — `compose`, `check`, `env`.
-- Docker Hub publishing added to 0000's release pipeline, on the same version gate
-  and the same OIDC identity, for `linux/amd64` and `linux/arm64`.
+- Docker Hub publishing added to 0000's release pipeline, on the same version gate,
+  for `linux/amd64` and `linux/arm64`. Authentication is `docker/login-action` with
+  the repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`; the push is
+  `docker/build-push-action` to `aisolutionslab/sobres`.
 
 ## The CLI is the entrypoint
 

--- a/openspec/changes/0005-docker-distribution/proposal.md
+++ b/openspec/changes/0005-docker-distribution/proposal.md
@@ -12,21 +12,21 @@ status: proposed
 One command, one image, the whole tool:
 
 ```bash
-docker run -p 8787:8787 -v quantfolio:/data espin086/quantfolio serve --host 0.0.0.0
+docker run -p 8787:8787 -v sobres:/data aisolutionslab/sobres serve --host 0.0.0.0
 ```
 
 The CLI is the image's entrypoint, so the container runs anything the tool can do:
 
 ```bash
-docker run -v quantfolio:/data espin086/quantfolio optimize markowitz --portfolio core
-docker run -v quantfolio:/data espin086/quantfolio db info
+docker run -v sobres:/data aisolutionslab/sobres optimize markowitz --portfolio core
+docker run -v sobres:/data aisolutionslab/sobres db info
 ```
 
 And the CLI generates the deployment rather than the user hand-writing it:
 
 ```bash
-qf deploy compose > docker-compose.yml    # generated from current config
-qf deploy check                           # what would run, with what config
+sobres deploy compose > docker-compose.yml    # generated from current config
+sobres deploy check                           # what would run, with what config
 ```
 
 ## Why
@@ -46,13 +46,13 @@ config resolution chain the CLI already uses keeps those the same thing.
 - Multi-stage `Dockerfile`: Node builds the 0004 frontend, Python builds the
   wheel, and a slim runtime stage carries neither toolchain.
 - `docker-compose.yml`, `.dockerignore`.
-- **New CLI group `qf deploy`** — `compose`, `check`, `env`.
+- **New CLI group `sobres deploy`** — `compose`, `check`, `env`.
 - Docker Hub publishing added to 0000's release pipeline, on the same version gate
   and the same OIDC identity, for `linux/amd64` and `linux/arm64`.
 
 ## The CLI is the entrypoint
 
-`ENTRYPOINT ["qf"]` rather than a shell or a server command. This is the decision
+`ENTRYPOINT ["sobres"]` rather than a shell or a server command. This is the decision
 that keeps the image honest: there is no container-only code path, no separate
 server binary, and no way for the containerized tool to diverge from the installed
 one. `docker run <image> <anything the CLI accepts>` works, and `serve` is just one
@@ -78,7 +78,7 @@ variable set in compose behaves exactly as it does in a shell.
 
 | Risk | Mitigation |
 |---|---|
-| The container writes the database to its own filesystem and the user loses everything on `docker rm` | `QUANTFOLIO_DB_URL` defaults to `sqlite:////data/quantfolio.db`; the image declares `/data` as a volume; startup fails loudly if `/data` is not writable, rather than silently persisting into the container layer |
+| The container writes the database to its own filesystem and the user loses everything on `docker rm` | `SOBRES_DB_URL` defaults to `sqlite:////data/sobres.db`; the image declares `/data` as a volume; startup fails loudly if `/data` is not writable, rather than silently persisting into the container layer |
 | Root-owned files in a mounted volume become unusable from the host | The image runs as a non-root user with a fixed, documented uid/gid |
 | Secrets baked into an image layer | Nothing is copied into the image but built artifacts; the build is proven secret-free by scanning the published image, and API keys arrive only as runtime environment or a mounted config |
 | Image bloat from a Node toolchain and scientific wheels | Multi-stage build discards both toolchains; a size budget is a CI gate |

--- a/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
+++ b/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
@@ -124,15 +124,37 @@
 
 #### Scenario: Provenance
 - **WHEN** an image is published
-- **THEN** a build attestation and an SBOM SHALL be attached, matching the
-  provenance guarantee 0000 already makes for the wheel
+- **THEN** `build-push-action` SHALL be configured with `provenance: mode=max` and
+  `sbom: true`, so BuildKit attaches a provenance attestation and an SBOM to the
+  manifest
+- **AND** the attestation SHALL be understood as a BuildKit build attestation, not
+  an OIDC-signed identity; the pipeline SHALL NOT claim provenance stronger than
+  that
+
+#### Scenario: Registry
+- **WHEN** an image is published
+- **THEN** the registry SHALL be Docker Hub
+- **AND** the repository SHALL be `aisolutionslab/sobres`
 
 #### Scenario: Credentials
-- **WHEN** the pipeline authenticates to the registry
-- **THEN** it SHALL use a scoped access token held as a repository secret, used by
-  no other job
+- **WHEN** the pipeline authenticates to Docker Hub
+- **THEN** it SHALL use `docker/login-action` with the repository secrets
+  `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
+- **AND** `DOCKERHUB_TOKEN` SHALL be a scoped Docker Hub access token with write
+  access to this repository only, never the account password
+- **AND** the secrets SHALL be repository-level, not organization-level, because
+  only this repository publishes an image; they move to the organization the day a
+  second repository needs them
+- **AND** they SHALL be read by the push job alone
 - **AND** publishing SHALL be disarmed by default, as PyPI publishing is, until
   explicitly enabled
+
+#### Scenario: Build and push
+- **WHEN** the push job runs
+- **THEN** it SHALL use `docker/setup-qemu-action`, `docker/setup-buildx-action`
+  and `docker/build-push-action`
+- **AND** the image SHALL be built once per release and pushed for every
+  architecture from that single build, not rebuilt per tag
 
 #### Scenario: Size budget
 - **WHEN** the image is built

--- a/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
+++ b/openspec/changes/0005-docker-distribution/specs/deployment/spec.md
@@ -6,7 +6,7 @@
 
 #### Scenario: The CLI is the entrypoint
 - **WHEN** the image runs with any arguments
-- **THEN** they SHALL be passed to `qf`
+- **THEN** they SHALL be passed to `sobres`
 - **AND** `docker run <image> --help` SHALL print the same help as a local install
 
 #### Scenario: No container-only code path
@@ -28,8 +28,8 @@
 ### Requirement: Data persistence in the container
 
 #### Scenario: Database lives on a volume
-- **WHEN** the image runs with no `QUANTFOLIO_DB_URL` set
-- **THEN** the database SHALL be SQLite at `/data/quantfolio.db`
+- **WHEN** the image runs with no `SOBRES_DB_URL` set
+- **THEN** the database SHALL be SQLite at `/data/sobres.db`
 - **AND** `/data` SHALL be declared as a volume
 
 #### Scenario: A missing volume fails loudly
@@ -43,7 +43,7 @@
 - **THEN** every saved portfolio, watchlist, goal, and run SHALL still be present
 
 #### Scenario: Host and container share one database
-- **WHEN** a host-side `qf` command and the container point at the same file
+- **WHEN** a host-side `sobres` command and the container point at the same file
 - **THEN** each SHALL see the other's writes, per 0003's portability requirement
 
 ### Requirement: Runtime security posture
@@ -81,7 +81,7 @@
   non-root user, resolved database URL, configured settings — with the same
   actionable lines as a local install
 
-#### Scenario: `qf open` in the container
+#### Scenario: `sobres open` in the container
 - **WHEN** `docker run <image> open` runs
 - **THEN** it SHALL print the URL to reach the UI from the host — using the
   published port when it can be determined, and the container port with a note
@@ -89,7 +89,7 @@
 - **AND** SHALL NOT attempt to launch a browser, since there is none
 
 #### Scenario: Non-interactive init in the container
-- **WHEN** `qf init` runs inside the container
+- **WHEN** `sobres init` runs inside the container
 - **THEN** it SHALL default to `--non-interactive`, reading settings from the
   environment, and SHALL exit 3 naming any missing required value rather than
   block on a prompt
@@ -108,7 +108,7 @@
 
 #### Scenario: Version parity is asserted
 - **WHEN** the image is built for release
-- **THEN** the version reported by `qf --version` inside it SHALL be asserted
+- **THEN** the version reported by `sobres --version` inside it SHALL be asserted
   equal to the wheel version being published
 - **AND** a mismatch SHALL fail the run before any push
 
@@ -153,7 +153,7 @@
   would grow unbounded in a layer nobody inspects
 
 #### Scenario: Log level is configurable at runtime
-- **WHEN** `QUANTFOLIO_LOG_LEVEL` is set in the environment
+- **WHEN** `SOBRES_LOG_LEVEL` is set in the environment
 - **THEN** it SHALL take effect with no image rebuild
 
 #### Scenario: Tracing is configured, not built in
@@ -169,24 +169,24 @@
 ### Requirement: The storage backend is a container concern too
 
 #### Scenario: The default stays SQLite on a volume
-- **WHEN** no `QUANTFOLIO_DB_URL` is supplied
-- **THEN** the container SHALL use SQLite at `/data/quantfolio.db`
+- **WHEN** no `SOBRES_DB_URL` is supplied
+- **THEN** the container SHALL use SQLite at `/data/sobres.db`
 
 #### Scenario: An external backend needs no different image
-- **WHEN** `QUANTFOLIO_DB_URL` names another registered backend
+- **WHEN** `SOBRES_DB_URL` names another registered backend
 - **THEN** the same image SHALL use it without rebuild
 - **AND** the `/data` volume SHALL become unnecessary, which
-  `qf deploy check` SHALL report rather than leave implied
+  `sobres deploy check` SHALL report rather than leave implied
 
 #### Scenario: A database URL is a secret
 - **WHEN** a connection URL containing credentials is supplied
-- **THEN** it SHALL be redacted in logs, spans, and every `qf deploy` output,
+- **THEN** it SHALL be redacted in logs, spans, and every `sobres deploy` output,
   under 0001's redaction rules
 
 ### Requirement: The CLI generates the deployment
 
 #### Scenario: Compose generation
-- **WHEN** `qf deploy compose` runs
+- **WHEN** `sobres deploy compose` runs
 - **THEN** a valid compose file SHALL print to stdout, with the image pinned to
   the running version, `/data` mounted, and the port published
 
@@ -202,18 +202,18 @@
   commit
 
 #### Scenario: Preflight
-- **WHEN** `qf deploy check` runs
+- **WHEN** `sobres deploy check` runs
 - **THEN** it SHALL run doctor's checks plus the deployment-specific ones below
 - **AND** it SHALL report the image and version, the resolved database path and
   whether it is writable, the bind address and port, whether a token is required
   and configured, and which credentials are present — naming each by key only
 
 #### Scenario: Exposure is called out
-- **WHEN** `qf deploy check` finds a non-loopback bind address with no token
+- **WHEN** `sobres deploy check` finds a non-loopback bind address with no token
 - **THEN** it SHALL report this as an error, not a warning
 
 #### Scenario: Environment template
-- **WHEN** `qf deploy env` runs
+- **WHEN** `sobres deploy env` runs
 - **THEN** a `.env` template SHALL print with every recognized variable, its
   default, and a one-line description
 - **AND** values of existing secrets SHALL NOT be included

--- a/openspec/changes/0006-landing-page/proposal.md
+++ b/openspec/changes/0006-landing-page/proposal.md
@@ -9,13 +9,13 @@ status: proposed
 
 ## Outcome
 
-A dark, animated single page at `https://espin086.github.io/Stocks/` that explains
-what quantfolio is in the time someone gives a link before closing the tab, and
+A dark, animated single page at `https://ai-solutions-lab-llc.github.io/sobres/` that explains
+what sobres is in the time someone gives a link before closing the tab, and
 sends them to one of two commands:
 
 ```bash
-pip install quantfolio-cli
-docker run -p 8787:8787 -v quantfolio:/data espin086/quantfolio serve --host 0.0.0.0
+pip install sobres
+docker run -p 8787:8787 -v sobres:/data aisolutionslab/sobres serve --host 0.0.0.0
 ```
 
 Published automatically from `main` by GitHub Actions.
@@ -29,7 +29,7 @@ seconds, and they decide on something moving.
 
 This tool's output is unusually well suited to that. An efficient frontier drawing
 itself along its curve *is* the explanation of what mean-variance optimization
-does. A terminal typing `qf optimize markowitz` and returning a weights table shows
+does. A terminal typing `sobres optimize markowitz` and returning a weights table shows
 the product working, in the product's own voice.
 
 It comes after 0005 because a landing page for something nobody can install yet is
@@ -58,7 +58,7 @@ output*, not decoration around it:
 
 1. **Hero** — an efficient frontier draws along its path; the max-Sharpe point
    lands last and labels itself.
-2. **Terminal** — a real `qf` command types itself and returns real output. The
+2. **Terminal** — a real `sobres` command types itself and returns real output. The
    text is the actual recorded output of that command, not invented.
 3. **Capabilities** — scroll-pinned sections, one per milestone, each with the
    command and the chart it produces.

--- a/openspec/changes/0007-equity-factor-analysis/proposal.md
+++ b/openspec/changes/0007-equity-factor-analysis/proposal.md
@@ -11,9 +11,9 @@ planning_depth: proposal + spec delta (design and tasks written when 0006 lands)
 ## Outcome
 
 ```bash
-qf analyze stock NVDA
-qf analyze factors NVDA --model ff5 --start 2015-01-01
-qf analyze factors --tickers AAPL MSFT NVDA --model ff5+mom --format csv
+sobres analyze stock NVDA
+sobres analyze factors NVDA --model ff5 --start 2015-01-01
+sobres analyze factors --tickers AAPL MSFT NVDA --model ff5+mom --format csv
 ```
 
 A single-stock dashboard, and a Fama-French regression that answers the question the
@@ -34,7 +34,7 @@ for the optimizer, and factor-tilted portfolio construction becomes possible.
 
 - **New capability `equity-analysis`**: `core/factors.py` (CAPM, FF3, FF5,
   FF5+momentum, rolling betas) and a fundamentals summary built on yfinance.
-- **New CLI group `qf analyze`**: `stock`, `factors`.
+- **New CLI group `sobres analyze`**: `stock`, `factors`.
 - `statsmodels` moves from the `econ` extra into the base install, or the regression
   is implemented on `numpy` directly — decided in design, based on whether the OLS
   diagnostics needed (HAC standard errors) justify the dependency.

--- a/openspec/changes/0007-equity-factor-analysis/specs/equity-analysis/spec.md
+++ b/openspec/changes/0007-equity-factor-analysis/specs/equity-analysis/spec.md
@@ -51,7 +51,7 @@ The system SHALL regress an asset's excess returns on published factor returns.
 ### Requirement: Single-stock analysis
 
 #### Scenario: Stock dashboard
-- **WHEN** `qf analyze stock NVDA` runs
+- **WHEN** `sobres analyze stock NVDA` runs
 - **THEN** the output SHALL include price summary, annualized return and volatility,
   the full risk panel from 0002, CAPM beta against `Mkt-RF`, and a fundamentals
   block (market cap, P/E, P/B, dividend yield, sector)
@@ -69,7 +69,7 @@ The system SHALL regress an asset's excess returns on published factor returns.
 ### Requirement: Multi-ticker factor comparison
 
 #### Scenario: Comparison table
-- **WHEN** `qf analyze factors --tickers AAPL MSFT NVDA --model ff5` runs
+- **WHEN** `sobres analyze factors --tickers AAPL MSFT NVDA --model ff5` runs
 - **THEN** one row per ticker SHALL print with its factor loadings, alpha,
   alpha t-statistic, and R²
 - **AND** rows SHALL be ordered as supplied, so output is diffable across runs

--- a/openspec/changes/0008-goal-planning/proposal.md
+++ b/openspec/changes/0008-goal-planning/proposal.md
@@ -11,10 +11,10 @@ planning_depth: proposal + spec delta (design and tasks written when 0007 lands)
 ## Outcome
 
 ```bash
-qf plan retire --income 200000 --expenses 90000 --portfolio 400000 --return 0.07
-qf plan house --price 950000 --down-pct 0.20 --by 2029-06-01 --monthly 3000
-qf plan car --price 45000 --by 2027-01-01 --current 5000
-qf plan goal --target 250000 --by 2032-01-01 --monthly 1500 --simulate 10000
+sobres plan retire --income 200000 --expenses 90000 --portfolio 400000 --return 0.07
+sobres plan house --price 950000 --down-pct 0.20 --by 2029-06-01 --monthly 3000
+sobres plan car --price 45000 --by 2027-01-01 --current 5000
+sobres plan goal --target 250000 --by 2032-01-01 --monthly 1500 --simulate 10000
 ```
 
 Deterministic answers to "when / how much," and a Monte Carlo distribution behind
@@ -36,7 +36,7 @@ whether holding it gets you there.
 - **New capability `goal-planning`**: `core/goals.py` (generic funding solver plus
   retirement, house, car, education specializations) and `core/simulate.py`
   (Monte Carlo and historical-bootstrap engines).
-- **New CLI group `qf plan`**: `retire`, `house`, `car`, `education`, `goal`.
+- **New CLI group `sobres plan`**: `retire`, `house`, `car`, `education`, `goal`.
 - Port `fire-calculator`'s core functions, with its tests carried over as regression
   fixtures so the ported math is provably identical.
 

--- a/openspec/changes/0008-goal-planning/specs/goal-planning/spec.md
+++ b/openspec/changes/0008-goal-planning/specs/goal-planning/spec.md
@@ -5,7 +5,7 @@
 ### Requirement: Real vs. nominal is always explicit
 
 #### Scenario: Mode selection
-- **WHEN** any `qf plan` command runs
+- **WHEN** any `sobres plan` command runs
 - **THEN** `--real` or `--nominal` SHALL determine whether returns and targets are
   inflation-adjusted
 - **AND** the default SHALL be `--real`, because a retirement target in nominal
@@ -49,7 +49,7 @@ return, given the other three.
 ### Requirement: Retirement / FIRE planning
 
 #### Scenario: FI number
-- **WHEN** `qf plan retire --expenses 90000` runs
+- **WHEN** `sobres plan retire --expenses 90000` runs
 - **THEN** the FI number SHALL be `annual_expenses / withdrawal_rate`, defaulting to
   a `0.04` withdrawal rate
 - **AND** the output SHALL state the rate used and name its origin
@@ -71,19 +71,19 @@ return, given the other three.
 ### Requirement: Named goal specializations
 
 #### Scenario: House
-- **WHEN** `qf plan house --price 950000 --down-pct 0.20 --by 2029-06-01` runs
+- **WHEN** `sobres plan house --price 950000 --down-pct 0.20 --by 2029-06-01` runs
 - **THEN** the down-payment target, required monthly saving, and whether the supplied
   `--monthly` meets it SHALL be reported
 - **AND** if `--price-growth` is supplied, the target SHALL grow with it, because a
   house price rising faster than savings is the actual risk
 
 #### Scenario: Car
-- **WHEN** `qf plan car --price 45000 --by 2027-01-01` runs
+- **WHEN** `sobres plan car --price 45000 --by 2027-01-01` runs
 - **THEN** the required monthly saving SHALL be reported, with `--depreciation`
   optionally reporting expected resale value at a later date
 
 #### Scenario: Education
-- **WHEN** `qf plan education --annual-cost 35000 --years 4 --starting 2038` runs
+- **WHEN** `sobres plan education --annual-cost 35000 --years 4 --starting 2038` runs
 - **THEN** the total inflated cost and required monthly saving SHALL be reported
 - **AND** education-cost inflation SHALL default to `5%`, separately from CPI, with
   the assumption stated
@@ -91,7 +91,7 @@ return, given the other three.
 ### Requirement: Monte Carlo and bootstrap simulation
 
 #### Scenario: Simulation is run by default
-- **WHEN** any `qf plan` command runs
+- **WHEN** any `sobres plan` command runs
 - **THEN** a simulation SHALL run and a success probability SHALL be reported
 - **AND** `--simulate 0` SHALL disable it for a purely deterministic answer
 
@@ -118,7 +118,7 @@ return, given the other three.
   be reproduced
 
 #### Scenario: Not advice
-- **WHEN** any `qf plan` command emits table output
+- **WHEN** any `sobres plan` command emits table output
 - **THEN** the not-investment-advice footer SHALL be present
 - **AND** the output SHALL state that taxes are not modeled and inputs are assumed
   after-tax

--- a/openspec/changes/0009-econometrics-forecasting/proposal.md
+++ b/openspec/changes/0009-econometrics-forecasting/proposal.md
@@ -11,10 +11,10 @@ planning_depth: proposal + spec delta (design and tasks written when 0008 lands)
 ## Outcome
 
 ```bash
-qf econ forecast CPIAUCSL --model arima --horizon 12
-qf econ volatility SPY --model garch --horizon 30
-qf econ diagnose DGS10          # stationarity, ACF/PACF, structural breaks
-qf econ regress --y AAPL --x SPY DGS10 --robust hac
+sobres econ forecast CPIAUCSL --model arima --horizon 12
+sobres econ volatility SPY --model garch --horizon 30
+sobres econ diagnose DGS10          # stationarity, ACF/PACF, structural breaks
+sobres econ regress --y AAPL --x SPY DGS10 --robust hac
 ```
 
 Time-series forecasting and regression diagnostics on the same data layer, with
@@ -35,7 +35,7 @@ being trustworthy first.
 - **New capability `econometrics`**: `core/timeseries.py` (stationarity tests,
   differencing, ARIMA, GARCH, forecast intervals) and `core/regression.py` (OLS with
   robust standard errors, multicollinearity and residual diagnostics).
-- **New CLI group `qf econ`**: `forecast`, `volatility`, `diagnose`, `regress`.
+- **New CLI group `sobres econ`**: `forecast`, `volatility`, `diagnose`, `regress`.
 - A GARCH-based covariance estimator registered into 0002's `core/moments.py`, which
   is why that module was built as a pluggable registry.
 - Reuse: `espin086/Econometrics` for statsmodels patterns, `espin086/jjutils`

--- a/openspec/changes/0009-econometrics-forecasting/specs/econometrics/spec.md
+++ b/openspec/changes/0009-econometrics-forecasting/specs/econometrics/spec.md
@@ -5,7 +5,7 @@
 ### Requirement: Stationarity diagnostics
 
 #### Scenario: Tests reported
-- **WHEN** `qf econ diagnose <series>` runs
+- **WHEN** `sobres econ diagnose <series>` runs
 - **THEN** ADF and KPSS test statistics, p-values, and conclusions SHALL be reported
 - **AND** disagreement between the two SHALL be stated explicitly rather than
   resolved silently
@@ -42,7 +42,7 @@
 ### Requirement: Volatility forecasting
 
 #### Scenario: GARCH fit
-- **WHEN** `qf econ volatility SPY --model garch` runs
+- **WHEN** `sobres econ volatility SPY --model garch` runs
 - **THEN** a GARCH(1,1) model SHALL be fitted to returns and a conditional
   volatility forecast SHALL be produced with intervals
 - **AND** `--model` SHALL also accept `egarch` and `ewma`
@@ -61,7 +61,7 @@
 ### Requirement: Regression with robust inference
 
 #### Scenario: Robust standard errors
-- **WHEN** `qf econ regress --robust <kind>` runs
+- **WHEN** `sobres econ regress --robust <kind>` runs
 - **THEN** `hac`, `hc0`–`hc3`, and `none` SHALL be accepted, and the kind used SHALL
   be named in the output
 
@@ -77,7 +77,7 @@
 ### Requirement: Dependency gating
 
 #### Scenario: Missing extra
-- **WHEN** a `qf econ` command runs without the `econ` extra installed
+- **WHEN** a `sobres econ` command runs without the `econ` extra installed
 - **THEN** the system SHALL exit 3 with
-  `This command needs the econ extra. Install it with: pip install 'quantfolio[econ]'`
+  `This command needs the econ extra. Install it with: pip install 'sobres[econ]'`
 - **AND** SHALL NOT emit an `ImportError` traceback

--- a/openspec/changes/0010-currency-and-ppp/proposal.md
+++ b/openspec/changes/0010-currency-and-ppp/proposal.md
@@ -11,20 +11,20 @@ planning_depth: proposal + spec deltas (design and tasks written when 0009 lands
 ## Outcome
 
 ```bash
-qf fx rates EURUSD USDJPY --start 2015-01-01
-qf fx convert 100000 --from USD --to EUR --on 2026-09-01
+sobres fx rates EURUSD USDJPY --start 2015-01-01
+sobres fx convert 100000 --from USD --to EUR --on 2026-09-01
 
 # How much of my international return was the company, and how much was the dollar?
-qf fx attribution --tickers NESN.SW 7203.T ASML.AS --base USD --start 2015-01-01
+sobres fx attribution --tickers NESN.SW 7203.T ASML.AS --base USD --start 2015-01-01
 
 # What would hedging have cost, and would it have helped?
-qf fx hedge --tickers ... --base USD --compare unhedged
+sobres fx hedge --tickers ... --base USD --compare unhedged
 
 # Is the dollar expensive against the euro right now, by PPP?
-qf ppp compare --base USD --vs EUR GBP MXN PTE
+sobres ppp compare --base USD --vs EUR GBP MXN PTE
 
 # My FIRE number is $2.1M for a US lifestyle. What is it in Portugal?
-qf ppp adjust-goal --goal fire --to PRT
+sobres ppp adjust-goal --goal fire --to PRT
 ```
 
 Two related things: **exchange rates**, which change what an international
@@ -40,7 +40,7 @@ correct; this change makes the currency component *visible* — how much of the
 return was the business and how much was the exchange rate, and what hedging would
 have cost.
 
-**For the plan.** This is the more useful half. `qf plan retire` produces a number
+**For the plan.** This is the more useful half. `sobres plan retire` produces a number
 for a lifestyle in one country. The question people actually have is whether that
 number goes further somewhere else, and PPP is the right tool for exactly that
 question — comparing what a currency *buys* rather than what it *trades for*.
@@ -60,7 +60,7 @@ building breadth on an unproven base.
 - **New capability `purchasing-power`** — `core/ppp.py`: absolute and relative PPP,
   real exchange rates, over/undervaluation against market rates, and PPP-adjusted
   restatement of any goal from 0008.
-- **New CLI groups** `qf fx` and `qf ppp`.
+- **New CLI groups** `sobres fx` and `sobres ppp`.
 - New `PppProvider` behind a protocol: World Bank ICP (`PA.NUS.PPP`, keyless) as
   the default, OECD PPP and comparative price levels as an alternative, and BIS
   published real effective exchange rates.
@@ -71,7 +71,7 @@ building breadth on an unproven base.
 
 - **No FX forecasting.** Exchange rates are close to a random walk at the horizons
   this tool works on, and PPP has essentially no short-run predictive power. A
-  `qf fx forecast` would be the single most misleading thing in the codebase.
+  `sobres fx forecast` would be the single most misleading thing in the codebase.
   PPP is reported as a *valuation gap*, never as a signal.
 - **No currency trading, carry strategies, or FX-timing backtests.** Reporting
   what the currency did is in scope; recommending a currency position is not.

--- a/openspec/changes/0010-currency-and-ppp/specs/fx-analytics/spec.md
+++ b/openspec/changes/0010-currency-and-ppp/specs/fx-analytics/spec.md
@@ -24,7 +24,7 @@ The system SHALL separate what the asset did from what the currency did.
 - **AND** the compounded components SHALL reconcile to the compounded total
 
 #### Scenario: Per-asset attribution
-- **WHEN** `qf fx attribution --tickers NESN.SW 7203.T --base USD` runs
+- **WHEN** `sobres fx attribution --tickers NESN.SW 7203.T --base USD` runs
 - **THEN** one row per ticker SHALL print with its local return, currency return,
   cross term, total, and the currency it is denominated in
 - **AND** a portfolio-level row SHALL aggregate them by weight
@@ -65,7 +65,7 @@ The system SHALL separate what the asset did from what the currency did.
 - **AND** SHALL NOT present it as an achievable realized return
 
 #### Scenario: Comparison
-- **WHEN** `qf fx hedge --tickers ... --base USD --compare unhedged` runs
+- **WHEN** `sobres fx hedge --tickers ... --base USD --compare unhedged` runs
 - **THEN** the risk panel from 0002 SHALL print for both hedged and unhedged
   series side by side
 - **AND** the hedge's cumulative cost or benefit over the window SHALL be reported
@@ -78,7 +78,7 @@ The system SHALL separate what the asset did from what the currency did.
 ### Requirement: Optimization in a base currency
 
 #### Scenario: Base currency is explicit
-- **WHEN** any `qf optimize` command receives assets in more than one currency
+- **WHEN** any `sobres optimize` command receives assets in more than one currency
 - **THEN** `--base` SHALL be required
 - **AND** returns SHALL be converted per 0001 before any moment is estimated
 
@@ -96,15 +96,15 @@ The system SHALL separate what the asset did from what the currency did.
 ### Requirement: FX commands
 
 #### Scenario: Rates
-- **WHEN** `qf fx rates EURUSD USDJPY --start 2015-01-01` runs
+- **WHEN** `sobres fx rates EURUSD USDJPY --start 2015-01-01` runs
 - **THEN** a date-indexed table of those pairs SHALL print, with the provider and
   any carried-forward dates noted
 
 #### Scenario: Conversion
-- **WHEN** `qf fx convert 100000 --from USD --to EUR --on 2026-09-01` runs
+- **WHEN** `sobres fx convert 100000 --from USD --to EUR --on 2026-09-01` runs
 - **THEN** the converted amount, the rate used, its date, and its source SHALL print
 - **AND** if the rate was carried forward from an earlier date, that SHALL be stated
 
 #### Scenario: No forecasting surface
-- **WHEN** the `qf fx` group is listed
+- **WHEN** the `sobres fx` group is listed
 - **THEN** no subcommand SHALL project, forecast, or recommend a future rate

--- a/openspec/changes/0010-currency-and-ppp/specs/purchasing-power/spec.md
+++ b/openspec/changes/0010-currency-and-ppp/specs/purchasing-power/spec.md
@@ -39,7 +39,7 @@ them separate and each output names which it used.
   levels, with the index and base period named
 
 #### Scenario: Over- and undervaluation
-- **WHEN** `qf ppp compare --base USD --vs EUR GBP MXN` runs
+- **WHEN** `sobres ppp compare --base USD --vs EUR GBP MXN` runs
 - **THEN** each row SHALL show the market rate, the PPP rate, and the percentage
   gap between them
 - **AND** the gap SHALL be labelled as a valuation gap, not as an expected move
@@ -75,7 +75,7 @@ them separate and each output names which it used.
 ### Requirement: PPP-adjusted goal planning
 
 #### Scenario: Restating a goal
-- **WHEN** `qf ppp adjust-goal --goal fire --to PRT` runs
+- **WHEN** `sobres ppp adjust-goal --goal fire --to PRT` runs
 - **THEN** the goal's target from 0008 SHALL be restated at the destination's
   price level, showing the original, the PPP factor, and the adjusted target
 - **AND** the equivalent figure at the market exchange rate SHALL be shown

--- a/openspec/changes/0011-rebrand-sobres/proposal.md
+++ b/openspec/changes/0011-rebrand-sobres/proposal.md
@@ -1,0 +1,89 @@
+---
+change: 0011-rebrand-sobres
+milestone: out-of-band
+depends_on: [0000-release-engineering]
+status: proposed
+---
+
+# 0011 — Rebrand to sobres
+
+## Outcome
+
+One name, everywhere:
+
+```bash
+pip install sobres
+sobres init
+sobres doctor
+sobres data prices AAPL MSFT --start 2015-01-01
+```
+
+```python
+from sobres.core.optimize import max_sharpe
+```
+
+The repository is `AI-Solutions-Lab-LLC/sobres`. The distribution, the import
+package, the console script, the environment prefix, the container image and the
+landing-page URL all read `sobres`, and nothing in the repository still says
+`quantfolio` or `qf`.
+
+## Why
+
+The project moved. It was `espin086/Stocks`, packaged as `quantfolio` with a `qf`
+console script; it now lives in the `AI-Solutions-Lab-LLC` organization under the
+name `sobres`. Carrying two names is the expensive part: a user reads `sobres` on
+GitHub, installs `quantfolio-cli`, and types `qf`. Every one of those is a place
+to get it wrong, and every published artifact that ships under the old name is one
+more thing to deprecate later.
+
+The `quantfolio` name was never usable on PyPI anyway — it is held by an unrelated
+2019 package, which is why `quantfolio-cli` existed as a fallback. `sobres` was
+unclaimed as of 2026-09-12, so the rename removes the fallback rather than
+replacing one workaround with another.
+
+Doing this before the first PyPI upload costs one mechanical pass. Doing it after
+costs a deprecation shim, a release note, and a name nobody can reclaim.
+
+## What changes
+
+| Surface | From | To |
+|---|---|---|
+| PyPI distribution | `quantfolio-cli` | `sobres` |
+| Import package | `src/quantfolio/` | `src/sobres/` |
+| Console script | `quantfolio`, `qf` | `sobres` |
+| Env var prefix | `QUANTFOLIO_` | `SOBRES_` |
+| Default DB path | `<user-data-dir>/quantfolio.db` | `<user-data-dir>/sobres.db` |
+| Container image | `espin086/quantfolio` | `aisolutionslab/sobres` |
+| Landing page | `espin086.github.io/Stocks` | `ai-solutions-lab-llc.github.io/sobres` |
+| Config / cache dir | `platformdirs("quantfolio")` | `platformdirs("sobres")` |
+
+The OpenSpec documents were rewritten to the new names on 2026-09-12. This change
+is what brings the code up to them, so until it lands the specs and the source
+disagree by design.
+
+## Non-goals
+
+- **No compatibility shim.** No `quantfolio` alias package, no `qf` alias script,
+  no env-var fallback. Nothing has been published under the old name, so there is
+  no installed base to keep working, and a shim would be permanent by accident.
+- **No behavior change.** Not one number the tool prints moves. If a test fixture
+  changes value, the rename broke something.
+- **No PEP 541 request** for the `quantfolio` name. It is abandoned, not contested.
+- **No re-tagging of history.** Old commits keep their paths; `git log --follow`
+  is the answer for archaeology.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A user's existing local database and config sit under the old `quantfolio` paths | `sobres doctor` detects a legacy directory and reports the exact `mv` to run; it does not move data silently |
+| The `sobres` name is claimed on PyPI before the first upload | Reserve it by publishing `0.0.0` as soon as this change merges, per 0000's release gate |
+| A stale `QUANTFOLIO_*` env var in someone's shell reads as unset and the tool silently uses a default | The settings registry refuses to start when any `QUANTFOLIO_*` variable is present, naming the `SOBRES_*` replacement |
+| The Docker Hub namespace is wrong | `aisolutionslab` is an assumption. Confirm the organization's actual Docker Hub account before 0005 publishes an image |
+
+## Open questions
+
+- Docker Hub namespace for the AI Solutions Lab organization — `aisolutionslab` is
+  a placeholder used consistently across these documents.
+- Whether the GitHub Pages site publishes from the repository or from an
+  organization-level pages repo, which decides the final URL path.

--- a/openspec/changes/0011-rebrand-sobres/specs/packaging/spec.md
+++ b/openspec/changes/0011-rebrand-sobres/specs/packaging/spec.md
@@ -1,0 +1,51 @@
+# packaging — spec delta (0011)
+
+## ADDED Requirements
+
+### Requirement: One name across every surface
+
+The distribution, import package, console script, and environment prefix SHALL all
+be `sobres`, and no artifact SHALL carry the former `quantfolio` or `qf` naming.
+
+#### Scenario: Installing
+- **WHEN** a user runs `pip install sobres`
+- **THEN** the distribution `sobres` SHALL install
+- **AND** exactly one console script SHALL be created, named `sobres`
+- **AND** the importable package SHALL be `sobres`
+
+#### Scenario: No residual old name
+- **WHEN** the repository is searched case-insensitively for `quantfolio`, or for
+  `qf` as a whole word
+- **THEN** there SHALL be no match outside `CHANGELOG.md`
+
+#### Scenario: Environment variables
+- **WHEN** the settings registry is enumerated
+- **THEN** every declared environment variable SHALL begin with `SOBRES_`
+
+### Requirement: Old names fail loudly, never silently
+
+Where a user's environment or filesystem still carries the former naming, the tool
+SHALL refuse to guess: it SHALL stop or report, name the replacement, and never
+migrate data on its own.
+
+#### Scenario: A stale environment variable
+- **WHEN** any `QUANTFOLIO_*` environment variable is set
+- **THEN** the process SHALL refuse to start
+- **AND** the error SHALL name the `SOBRES_*` variable that replaces it
+
+#### Scenario: A legacy data directory
+- **WHEN** `sobres doctor` runs and a `quantfolio` config or data directory exists
+- **THEN** the check SHALL report actionable
+- **AND** SHALL print the exact command to move the directory
+- **AND** SHALL NOT move, copy, or delete any file itself
+
+### Requirement: The rename changes no behavior
+
+The rename SHALL be a pure identifier change. No computed value, output format, or
+test fixture SHALL differ because of it.
+
+#### Scenario: Identical results
+- **WHEN** any command runs against the same cached inputs and seed before and
+  after the rename
+- **THEN** stdout SHALL be byte-identical apart from the program name
+- **AND** every test fixture value SHALL be unchanged

--- a/openspec/changes/0011-rebrand-sobres/tasks.md
+++ b/openspec/changes/0011-rebrand-sobres/tasks.md
@@ -1,0 +1,54 @@
+# 0011 — tasks
+
+## A. Package identity
+
+- [ ] **A1. Rename the source tree** `src/quantfolio/` → `src/sobres/` with
+      `git mv` so history follows. → test: `pytest` collects and passes unchanged.
+- [ ] **A2. `pyproject.toml`** — `name = "sobres"`, `[project.scripts] sobres =
+      "sobres.cli.main:app"`, drop the second entry point, update `packages`,
+      `tool.hatch.version.path`, coverage source, and mypy/ruff path settings.
+      → test: `tests/test_packaging.py` asserts the installed distribution is
+      `sobres` and exactly one console script exists.
+- [ ] **A3. Import rewrite** — every `from quantfolio` / `import quantfolio`.
+      → test: a grep test asserts the string `quantfolio` appears nowhere under
+      `src/`, `tests/`, or `docs/`.
+
+## B. Runtime names
+
+- [ ] **B1. Settings prefix** `QUANTFOLIO_*` → `SOBRES_*` in the settings
+      registry. → test: every declared setting's env var starts with `SOBRES_`.
+- [ ] **B2. Legacy env guard** — startup fails with a named replacement when any
+      `QUANTFOLIO_*` variable is set. → test: a fixture sets `QUANTFOLIO_DB_URL`
+      and asserts the error names `SOBRES_DB_URL`.
+- [ ] **B3. Paths** — `platformdirs` app name, default DB filename `sobres.db`.
+      → test: the default DB URL resolves under a `sobres` data dir.
+- [ ] **B4. Legacy data check** — a doctor check that finds an old `quantfolio`
+      config or data directory and prints the `mv` to run, without moving it.
+      → test: the check reports actionable when a fake legacy dir exists.
+
+## C. Published surfaces
+
+- [ ] **C1. Docker** — image name `aisolutionslab/sobres`, volume examples, and
+      the health check calling `sobres doctor`. → test: `sobres deploy check`
+      output contains no `quantfolio`.
+- [ ] **C2. Landing page** — base URL, install snippet, and every command example.
+      → test: the site build fails on the string `qf `.
+- [ ] **C3. Docs and README** — install line, quickstart, every command example,
+      `docs/RELEASING.md`. → test: the repository-wide grep test from A3 covers
+      markdown too.
+- [ ] **C4. CI** — workflow names, artifact names, cache keys, and the PyPI
+      environment. → test: a dry-run release to TestPyPI uploads `sobres`.
+
+## D. Reserve the name
+
+- [ ] **D1. Publish `0.0.0`** to PyPI as `sobres` to hold the name, per 0000's
+      armed-release gate. → test: `check_release.py` reports the name as held by
+      this project.
+
+## Definition of done
+
+- [ ] `rg -i quantfolio` and `rg -w qf` return nothing outside `CHANGELOG.md`
+- [ ] `pip install -e .` then `sobres doctor` passes on a clean environment
+- [ ] Every test that passed before the rename passes after it, with identical
+      fixture values
+- [ ] `openspec validate` is clean

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,15 +1,15 @@
 schema: spec-driven
 
 context: |
-  quantfolio is a Python 3.11+ CLI and library for equity analysis.
+  sobres is a Python 3.11+ CLI and library for equity analysis.
 
   Hard architectural rule (inherited from espin086/fire-calculator, which proved it):
-  ALL math and business logic live in `src/quantfolio/core/**` as pure, I/O-free
+  ALL math and business logic live in `src/sobres/core/**` as pure, I/O-free
   functions over plain dataclasses / pandas objects. Every other surface — the Typer
   CLI, any future FastAPI app, any notebook helper — is a thin adapter that imports
   core and holds no business logic of its own.
 
-  Data access is the other pure boundary: `src/quantfolio/data/**` owns all network
+  Data access is the other pure boundary: `src/sobres/data/**` owns all network
   I/O and caching and returns plain pandas objects. Core never performs I/O; adapters
   never do math.
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -278,6 +278,40 @@ came before it.
 0011 is out of band: it renames the project and can land at any point, though the
 longer it waits the more published artifacts carry the old name.
 
+## Versioning and releasing
+
+SemVer, and the version has exactly one home: `src/sobres/__about__.py`. Nothing
+else declares it. `pyproject.toml` reads it dynamically, the wheel metadata, the
+container tag, and `sobres --version` all derive from it, and a packaging test
+fails the build if any of them disagree.
+
+**The version bump is the release trigger.** Merging a bump to `main` publishes;
+any other merge publishes nothing and says so. There is no separate release
+command to remember and no window where `main` is "about to be" released.
+
+| Rule | Enforced by |
+|---|---|
+| One version source | `tests/test_packaging.py` asserts installed metadata parity |
+| A published version is never re-published | `check_release.py` queries the index and fails closed on any non-404 error |
+| Every version has a CHANGELOG section | the release gate refuses a bump without one |
+| Every published version is tagged and has a GitHub release | the publish job creates both, from the CHANGELOG section |
+| Nothing publishes from a red build | `release.yml` calls `ci.yml` via `workflow_call`; one definition of green |
+| Nothing publishes from an unreviewed commit | `main` is protected: pull request required, `All checks passed` required, admin-only merge, linear history |
+| Publishing is off until deliberately armed | the repository variable `RELEASE_ENABLED` must be `true` |
+
+Pre-1.0 the minor version carries breaking changes. From v1.0.0 — shipped by 0002 —
+the CLI's command surface, its `--format json` shapes, and the `sobres.core` public
+functions are the compatibility surface, and breaking any of them is a major bump.
+Anything under a module named `_internal` is not part of it.
+
+Credentials, by index and registry:
+
+| Target | Credential | Scope |
+|---|---|---|
+| PyPI | `PYPI_PROD` | organization secret, shared across `AI-Solutions-Lab-LLC` |
+| TestPyPI | `PYPI_TEST` | organization secret |
+| Docker Hub | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` | repository secrets — only this repository publishes an image |
+
 ## Non-negotiables
 
 1. **Not investment advice.** Every report-style output carries a disclaimer footer.
@@ -296,3 +330,6 @@ longer it waits the more published artifacts carry the old name.
    the build fails if it does not.
 9. **No forecasting of exchange rates, ever.** PPP is reported as a valuation
    gap, never as a signal, a target, or a convergence path.
+10. **Every release is versioned, gated, and recorded.** Nothing reaches an index
+    or a registry except through the pipeline in 0000, from a green `main`, with a
+    CHANGELOG section and a git tag. No manual upload, ever.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,4 +1,20 @@
-# quantfolio — project context
+# sobres — project context
+
+## Where it lives
+
+| What | Value |
+|---|---|
+| Repository | `AI-Solutions-Lab-LLC/sobres` — https://github.com/AI-Solutions-Lab-LLC/sobres |
+| PyPI distribution | `sobres` (unclaimed as of 2026-09-12) |
+| Import package | `sobres` (`src/sobres/`) |
+| Console script | `sobres` |
+| Container image | `aisolutionslab/sobres` on Docker Hub |
+| Landing page | https://ai-solutions-lab-llc.github.io/sobres/ |
+| Env var prefix | `SOBRES_` |
+
+The project was previously `espin086/Stocks`, packaged as `quantfolio` / `quantfolio-cli`
+with a `qf` console script. Change 0011 carries that rename through the code; every
+document here already uses the new names.
 
 ## What this is
 
@@ -49,7 +65,7 @@ makes the UI cheap — it is a third adapter, not a second implementation.
 ## Package layout (target)
 
 ```
-src/quantfolio/
+src/sobres/
 ├── __about__.py
 ├── config.py               # settings: cache dir, API keys from env, defaults
 ├── core/
@@ -92,31 +108,31 @@ site/                       # 0006: animated landing page → GitHub Pages
 
 | Command | Does |
 |---|---|
-| `qf init` | Guided setup of every declared setting; ends by running doctor |
-| `qf doctor` | Every check actionable; `--fix` for safe repairs; `--format json` |
-| `qf upgrade` | Detects the installer and runs the matching upgrade |
-| `qf data prices AAPL MSFT --start 2015-01-01` | Fetch + cache price history |
-| `qf data macro DGS10 CPIAUCSL` | Fetch FRED series |
-| `qf analyze stock NVDA` | Fundamentals, risk, CAPM beta |
-| `qf analyze factors NVDA --model ff5` | Fama-French regression, alpha + t-stats |
-| `qf optimize markowitz --tickers ... --objective max-sharpe` | Optimal weights |
-| `qf optimize frontier --tickers ... --points 50` | Efficient frontier |
-| `qf optimize backtest --weights ... --rebalance quarterly` | Walk-forward test |
-| `qf plan retire --income ... --expenses ...` | FIRE number + date |
-| `qf plan house --price ... --down-pct ...` | Savings path to a down payment |
-| `qf plan goal --target ... --by 2032-01-01` | Generic funding solver |
-| `qf econ forecast CPIAUCSL --model arima` | Time-series forecast |
-| `qf fx rates EURUSD` / `qf fx convert 1000 --from USD --to EUR` | Exchange rates and conversion |
-| `qf fx attribution --tickers ... --base USD` | Split return into asset vs currency |
-| `qf fx hedge --tickers ... --compare unhedged` | What hedging would have cost |
-| `qf ppp compare --base USD --vs EUR MXN` | Market rate vs purchasing-power rate |
-| `qf ppp adjust-goal --goal fire --to PRT` | Restate a goal at another price level |
-| `qf portfolio save core --tickers ...` | Save a named portfolio |
-| `qf run list` / `qf run show <id>` | Browse saved analysis runs |
-| `qf db info` / `qf db export --to ...` | Inspect and back up the database |
-| `qf serve --host 0.0.0.0` | Run the web UI and API |
-| `qf open [doctor\|settings\|run 42\|...]` | Start the server if needed and open the browser to a view |
-| `qf deploy compose` / `qf deploy check` | Generate and verify a deployment |
+| `sobres init` | Guided setup of every declared setting; ends by running doctor |
+| `sobres doctor` | Every check actionable; `--fix` for safe repairs; `--format json` |
+| `sobres upgrade` | Detects the installer and runs the matching upgrade |
+| `sobres data prices AAPL MSFT --start 2015-01-01` | Fetch + cache price history |
+| `sobres data macro DGS10 CPIAUCSL` | Fetch FRED series |
+| `sobres analyze stock NVDA` | Fundamentals, risk, CAPM beta |
+| `sobres analyze factors NVDA --model ff5` | Fama-French regression, alpha + t-stats |
+| `sobres optimize markowitz --tickers ... --objective max-sharpe` | Optimal weights |
+| `sobres optimize frontier --tickers ... --points 50` | Efficient frontier |
+| `sobres optimize backtest --weights ... --rebalance quarterly` | Walk-forward test |
+| `sobres plan retire --income ... --expenses ...` | FIRE number + date |
+| `sobres plan house --price ... --down-pct ...` | Savings path to a down payment |
+| `sobres plan goal --target ... --by 2032-01-01` | Generic funding solver |
+| `sobres econ forecast CPIAUCSL --model arima` | Time-series forecast |
+| `sobres fx rates EURUSD` / `sobres fx convert 1000 --from USD --to EUR` | Exchange rates and conversion |
+| `sobres fx attribution --tickers ... --base USD` | Split return into asset vs currency |
+| `sobres fx hedge --tickers ... --compare unhedged` | What hedging would have cost |
+| `sobres ppp compare --base USD --vs EUR MXN` | Market rate vs purchasing-power rate |
+| `sobres ppp adjust-goal --goal fire --to PRT` | Restate a goal at another price level |
+| `sobres portfolio save core --tickers ...` | Save a named portfolio |
+| `sobres run list` / `sobres run show <id>` | Browse saved analysis runs |
+| `sobres db info` / `sobres db export --to ...` | Inspect and back up the database |
+| `sobres serve --host 0.0.0.0` | Run the web UI and API |
+| `sobres open [doctor\|settings\|run 42\|...]` | Start the server if needed and open the browser to a view |
+| `sobres deploy compose` / `sobres deploy check` | Generate and verify a deployment |
 
 ## Data sources
 
@@ -129,7 +145,7 @@ site/                       # 0006: animated landing page → GitHub Pages
 | **World Bank ICP / OECD** | no | PPP conversion factors, comparative price levels | 0010 |
 | **BIS** | no | Published real effective exchange rates | 0010 |
 
-`pip install quantfolio-cli` must produce a working tool with **no keys
+`pip install sobres` must produce a working tool with **no keys
 configured**. Anything requiring a key degrades with a clear, actionable error —
 never a stack trace.
 
@@ -138,18 +154,18 @@ never a stack trace.
 Three commands, kept to three by construction:
 
 ```
-pip install quantfolio-cli  →  qf init  →  qf doctor
+pip install sobres  →  sobres init  →  sobres doctor
 ```
 
 **Settings are declared once**, like commands. Each carries its env var, whether
-it is a secret, how to obtain it, and an optional live validator; `qf init`,
-`qf doctor`, `qf config`, and the 0004 settings page all derive from the
+it is a secret, how to obtain it, and an optional live validator; `sobres init`,
+`sobres doctor`, `sobres config`, and the 0004 settings page all derive from the
 declaration. A test asserts every env var the code reads is a declared setting.
 
 **Doctor's checks are declared once**, too — a `Check` registry with `run` and
 an optional idempotent `fix`. A milestone that adds a provider, a setting, or a
 runtime dependency registers a check in the same change; a test asserts every
-setting and provider has one. Every failing line carries its next step. `qf
+setting and provider has one. Every failing line carries its next step. `sobres
 deploy check` and the container health check call doctor rather than
 re-implementing health.
 
@@ -160,8 +176,8 @@ Persistence is reachable only through repository protocols in
 portfolios — never as SQL execution. A port phrased as SQL is a SQL port, and
 swapping it would still be a rewrite.
 
-`QUANTFOLIO_DB_URL` selects the adapter, defaulting to
-`sqlite:///<user-data-dir>/quantfolio.db`. **No database driver is imported
+`SOBRES_DB_URL` selects the adapter, defaulting to
+`sqlite:///<user-data-dir>/sobres.db`. **No database driver is imported
 outside `data/storage/adapters/`**, and a test enforces it.
 
 SQLAlchemy Core (the expression language, not the ORM) sits *below* the
@@ -241,22 +257,26 @@ Each is one OpenSpec change under `openspec/changes/`.
 | # | Change | Ships |
 |---|---|---|
 | 0000 | `release-engineering` | CI gate, version-gated PyPI publishing |
-| 0001 | `foundation-data-and-cli` | Onboarding (`init`/`doctor`/`upgrade`), command registry, storage port + SQLite adapter, providers, data quality, currency model, logging + tracing, test scaffolding, `qf data *` |
+| 0001 | `foundation-data-and-cli` | Onboarding (`init`/`doctor`/`upgrade`), command registry, storage port + SQLite adapter, providers, data quality, currency model, logging + tracing, test scaffolding, `sobres data *` |
 | 0002 | `portfolio-optimization` | **v1.0.0** — returns/risk, MVO, frontier, backtest |
-| 0003 | `local-persistence` | Schema + migrations, saved portfolios/goals/runs, `qf db` |
-| 0004 | `web-ui` | API and UI derived from the registry, React SPA, jobs + SSE, `qf serve`, `qf open` |
-| 0005 | `docker-distribution` | One image on Docker Hub, CLI entrypoint, `qf deploy` |
+| 0003 | `local-persistence` | Schema + migrations, saved portfolios/goals/runs, `sobres db` |
+| 0004 | `web-ui` | API and UI derived from the registry, React SPA, jobs + SSE, `sobres serve`, `sobres open` |
+| 0005 | `docker-distribution` | One image on Docker Hub, CLI entrypoint, `sobres deploy` |
 | 0006 | `landing-page` | Animated dark GitHub Pages site |
 | 0007 | `equity-factor-analysis` | Single-stock analysis, CAPM, Fama-French 3/5 + momentum |
 | 0008 | `goal-planning` | Retirement/FIRE, house, car, education, Monte Carlo |
 | 0009 | `econometrics-forecasting` | ARIMA/GARCH forecasting, stationarity, macro overlays |
 | 0010 | `currency-and-ppp` | FX attribution and hedging, PPP comparison, PPP-adjusted goals |
+| 0011 | `rebrand-sobres` | Rename through the code: import package, console script, env vars, image, pages URL |
 
 0001 → 0002 is the v1.0.0 release. 0003 → 0006 turn it into a deployable product
 with a UI. 0007–0009 then add analytics to a UI that already exists, rather than
 retrofitting one at the end. 0010 makes the whole tool international, last because
 it is the change that touches every earlier one. Each change depends only on what
 came before it.
+
+0011 is out of band: it renames the project and can land at any point, though the
+longer it waits the more published artifacts carry the old name.
 
 ## Non-negotiables
 


### PR DESCRIPTION
## What

The project moved from `espin086/Stocks` to `AI-Solutions-Lab-LLC/sobres`. The OpenSpec documents still described it as **quantfolio**, packaged as `quantfolio-cli` with a `qf` console script, published from a personal namespace. This brings the specs in line with where the project actually lives.

## Renames, across all 36 OpenSpec documents

| Surface | From | To |
|---|---|---|
| Distribution | `quantfolio-cli` | `sobres` |
| Import package | `quantfolio` | `sobres` |
| Console script | `qf` | `sobres` |
| Env prefix | `QUANTFOLIO_` | `SOBRES_` |
| Container image | `espin086/quantfolio` | `aisolutionslab/sobres` |
| Landing page | `espin086.github.io/Stocks` | `ai-solutions-lab-llc.github.io/sobres` |

`quantfolio-cli` only existed because `quantfolio` is held on PyPI by an unrelated 2019 package. `sobres` is unclaimed as of 2026-09-12 (PyPI returns 404), so the fallback is removed rather than replaced.

Prior-art references to `espin086/fire-calculator`, `espin086/jjutils` and friends are unchanged — those repos did not move.

## New change: 0011-rebrand-sobres

The specs now describe names the code does not use, by design. 0011 carries the rename through `src/`, `pyproject.toml`, CI, docs and the image, with no compatibility shim (nothing has been published under the old name) and a doctor check that finds a legacy `quantfolio` data directory and prints the `mv` rather than moving anything itself.

## 0000-release-engineering

- **Publishing now uses the organization secrets `PYPI_PROD` and `PYPI_TEST`** instead of Trusted Publishing. The tradeoff is stated plainly in the spec: an org-scoped token has an org-sized blast radius, and PEP 740 attestations are produced only by OIDC, so the pipeline no longer claims provenance it does not generate. Trusted Publishing stays documented as the upgrade path.
- A repo-level secret named `PYPI_PROD` or `PYPI_TEST` is specified as a configuration error, since it silently shadows the org value.
- **Branch protection is now specified**, matching what is live on `main`: pull request required, `All checks passed` required, strict up-to-date branches, admin-only merge, linear history, no force push or deletion.

## Verification

- `openspec validate 0011-rebrand-sobres --type change` → valid
- No residual `quantfolio` or whole-word `qf` anywhere under `openspec/`
- The new and edited requirements raise no validator findings

## Known, not fixed here

- 11 of the 12 existing changes fail `openspec validate --all` with "ADDED ... is missing requirement text". That predates this PR — the repo's specs put scenarios directly under a `### Requirement:` heading with no prose. Worth a separate cleanup pass.
- `aisolutionslab` is an assumed Docker Hub namespace. Confirm the org's real account before 0005 publishes an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD8BYWZzUDX33cpQ4kBbnE