### PR TITLE
0007: Equity and factor analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ describe. See [docs/RELEASING.md](docs/RELEASING.md).
 ## [Unreleased]
 
 ### Added
+- **Equity and factor analysis (change 0007).** `sobres analyze factors`
+  (CAPM, FF3, FF5, FF5+momentum on excess returns; OLS and Newey-West
+  statistics per term; annualized alpha with an explicit "not distinguishable
+  from zero" statement; `--rolling` loadings; a multi-ticker comparison table
+  in the order supplied) and `sobres analyze stock` (price summary, risk panel,
+  CAPM beta, current fundamentals with the point-in-time caveat).
+  `core/factors.py` is numpy-only; `statsmodels` stays an extra.
+
+### Fixed
+- Cached factor frames came back with an empty `Mkt-RF` column: the
+  observation cache upper-cased symbols before asking the provider. Keys are
+  still stored upper-cased; the caller's casing is now restored on the way out.
 - **Landing page (change 0006).** `site/`: a dark, static Vite + TypeScript page
   at ai-solutions-lab-llc.github.io/sobres with an efficient frontier that draws
   itself, a terminal replaying a recorded `sobres optimize markowitz` transcript,

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ the milestone plans in [`openspec/changes/`](openspec/changes/).
 | [0004](openspec/changes/0004-web-ui/) | Web UI | FastAPI + React SPA derived from the registry, `sobres serve`, `sobres open` | ✅ Done |
 | [0005](openspec/changes/0005-docker-distribution/) | Docker | One image on Docker Hub, `sobres deploy` | ✅ Done |
 | [0006](openspec/changes/0006-landing-page/) | Landing page | Animated dark GitHub Pages site | ✅ Done |
-| [0007](openspec/changes/0007-equity-factor-analysis/) | Factor analysis | CAPM, Fama-French 3/5 + momentum | 📋 Planned |
+| [0007](openspec/changes/0007-equity-factor-analysis/) | Factor analysis | CAPM, Fama-French 3/5 + momentum | ✅ Done |
 | [0008](openspec/changes/0008-goal-planning/) | Goal planning | Retirement/FIRE, house, car, education, Monte Carlo | 📋 Planned |
 | [0009](openspec/changes/0009-econometrics-forecasting/) | Econometrics | ARIMA, GARCH, robust regression | 📋 Planned |
 | [0010](openspec/changes/0010-currency-and-ppp/) | Exchange rates & PPP | FX attribution, hedging, PPP-adjusted goals | 📋 Planned |
@@ -138,6 +138,23 @@ in-sample result is labelled as such. A multi-currency universe needs `--base`;
 returns are converted before any moment is estimated. Read
 [why your backtest looks too good](docs/why-your-backtest-looks-too-good.md)
 before trusting the Sharpe ratio.
+
+## Quickstart: factor analysis
+
+```bash
+sobres analyze stock NVDA --start 2015-01-01 --fill drop
+sobres analyze factors NVDA --model ff5 --start 2015-01-01 --fill drop
+sobres analyze factors --tickers AAPL MSFT NVDA --model ff5+mom --start 2015-01-01 --fill drop --format csv
+sobres analyze factors NVDA --rolling 36 --start 2015-01-01 --fill drop
+```
+
+Excess returns (`r - RF`, with `RF` from the same Ken French file) regressed on
+CAPM, Fama-French 3 or 5 factors, or 5 + momentum, monthly by default. Every
+coefficient carries OLS and Newey-West standard errors, t-statistics and
+p-values; alpha is annualized and, when its HAC p-value exceeds 0.05, the output
+says it is not distinguishable from zero. `analyze stock` adds the price summary,
+the 0002 risk panel, CAPM beta and current fundamentals with the note that they
+are not point-in-time.
 
 ## Quickstart: saved state
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -403,6 +403,155 @@
         "title": "EnvParams",
         "type": "object"
       },
+      "FactorParams": {
+        "additionalProperties": false,
+        "properties": {
+          "base": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Base currency for a multi-currency universe (e.g. USD).",
+            "title": "Base"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last date (default: today).",
+            "title": "End"
+          },
+          "fill": {
+            "description": "Provider-gap policy: drop, ffill or raise. No default.",
+            "enum": [
+              "drop",
+              "ffill",
+              "raise"
+            ],
+            "title": "Fill",
+            "type": "string"
+          },
+          "frequency": {
+            "default": "monthly",
+            "description": "Return frequency; monthly matches the published factors.",
+            "enum": [
+              "monthly",
+              "daily"
+            ],
+            "title": "Frequency",
+            "type": "string"
+          },
+          "hac_lags": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Newey-West lag length; default: the Newey-West (1994) rule.",
+            "title": "Hac Lags"
+          },
+          "model": {
+            "default": "ff3",
+            "description": "Factor model.",
+            "enum": [
+              "capm",
+              "ff3",
+              "ff5",
+              "ff5+mom"
+            ],
+            "title": "Model",
+            "type": "string"
+          },
+          "portfolio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A saved portfolio's name in place of --tickers.",
+            "title": "Portfolio"
+          },
+          "rolling": {
+            "anyOf": [
+              {
+                "minimum": 6.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Window (in periods) for rolling loadings instead of one fit.",
+            "title": "Rolling"
+          },
+          "save_run": {
+            "default": false,
+            "description": "Record this run in the run history.",
+            "title": "Save Run",
+            "type": "boolean"
+          },
+          "start": {
+            "description": "First date, YYYY-MM-DD.",
+            "format": "date",
+            "title": "Start",
+            "type": "string"
+          },
+          "ticker": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One ticker (or use --tickers for a comparison table).",
+            "positional": true,
+            "title": "Ticker"
+          },
+          "tickers": {
+            "anyOf": [
+              {
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Several tickers for a comparison table (or use --portfolio).",
+            "title": "Tickers"
+          }
+        },
+        "required": [
+          "start",
+          "fill"
+        ],
+        "title": "FactorParams",
+        "type": "object"
+      },
       "FactorsParams": {
         "additionalProperties": false,
         "properties": {
@@ -1373,6 +1522,66 @@
         "title": "SettingBody",
         "type": "object"
       },
+      "StockParams": {
+        "additionalProperties": false,
+        "properties": {
+          "end": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last date (default: today).",
+            "title": "End"
+          },
+          "fill": {
+            "description": "Provider-gap policy: drop, ffill or raise. No default.",
+            "enum": [
+              "drop",
+              "ffill",
+              "raise"
+            ],
+            "title": "Fill",
+            "type": "string"
+          },
+          "risk_free": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Annual decimal risk-free rate for the risk panel.",
+            "title": "Risk Free"
+          },
+          "start": {
+            "default": "2015-01-01",
+            "description": "First date, YYYY-MM-DD.",
+            "format": "date",
+            "title": "Start",
+            "type": "string"
+          },
+          "ticker": {
+            "description": "Ticker symbol, e.g. NVDA.",
+            "minLength": 1,
+            "positional": true,
+            "title": "Ticker",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ticker",
+          "fill"
+        ],
+        "title": "StockParams",
+        "type": "object"
+      },
       "TokenRotateParams": {
         "additionalProperties": false,
         "properties": {
@@ -1577,6 +1786,86 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/analyze/factors": {
+      "post": {
+        "description": "Regress excess returns on CAPM or Fama-French factors; alpha with its t-statistic.",
+        "operationId": "analyze_factors_api_v1_analyze_factors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FactorParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Regress excess returns on CAPM or Fama-French factors; alpha with its t-statistic.",
+        "tags": [
+          "analyze"
+        ]
+      }
+    },
+    "/api/v1/analyze/stock": {
+      "post": {
+        "description": "Price summary, risk panel, CAPM beta and fundamentals for one stock.",
+        "operationId": "analyze_stock_api_v1_analyze_stock_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StockParams"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Price summary, risk panel, CAPM beta and fundamentals for one stock.",
+        "tags": [
+          "analyze"
+        ]
+      }
+    },
     "/api/v1/auth/login": {
       "post": {
         "operationId": "login_api_v1_auth_login_post",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -48,6 +48,8 @@
     "watchlist.delete": "/commands/watchlist.delete",
     "watchlist.list": "/commands/watchlist.list",
     "watchlist.remove": "/commands/watchlist.remove",
-    "watchlist.show": "/commands/watchlist.show"
+    "watchlist.show": "/commands/watchlist.show",
+    "analyze.stock": "/commands/analyze.stock",
+    "analyze.factors": "/commands/analyze.factors"
   }
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4,6 +4,46 @@
  */
 
 export interface paths {
+    "/api/v1/analyze/factors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regress excess returns on CAPM or Fama-French factors; alpha with its t-statistic.
+         * @description Regress excess returns on CAPM or Fama-French factors; alpha with its t-statistic.
+         */
+        post: operations["analyze_factors_api_v1_analyze_factors_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/analyze/stock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Price summary, risk panel, CAPM beta and fundamentals for one stock.
+         * @description Price summary, risk panel, CAPM beta and fundamentals for one stock.
+         */
+        post: operations["analyze_stock_api_v1_analyze_stock_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/auth/login": {
         parameters: {
             query?: never;
@@ -1213,6 +1253,76 @@ export interface components {
         };
         /** EnvParams */
         EnvParams: Record<string, never>;
+        /** FactorParams */
+        FactorParams: {
+            /**
+             * Base
+             * @description Base currency for a multi-currency universe (e.g. USD).
+             */
+            base?: string | null;
+            /**
+             * End
+             * @description Last date (default: today).
+             */
+            end?: string | null;
+            /**
+             * Fill
+             * @description Provider-gap policy: drop, ffill or raise. No default.
+             * @enum {string}
+             */
+            fill: "drop" | "ffill" | "raise";
+            /**
+             * Frequency
+             * @description Return frequency; monthly matches the published factors.
+             * @default monthly
+             * @enum {string}
+             */
+            frequency: "monthly" | "daily";
+            /**
+             * Hac Lags
+             * @description Newey-West lag length; default: the Newey-West (1994) rule.
+             */
+            hac_lags?: number | null;
+            /**
+             * Model
+             * @description Factor model.
+             * @default ff3
+             * @enum {string}
+             */
+            model: "capm" | "ff3" | "ff5" | "ff5+mom";
+            /**
+             * Portfolio
+             * @description A saved portfolio's name in place of --tickers.
+             */
+            portfolio?: string | null;
+            /**
+             * Rolling
+             * @description Window (in periods) for rolling loadings instead of one fit.
+             */
+            rolling?: number | null;
+            /**
+             * Save Run
+             * @description Record this run in the run history.
+             * @default false
+             */
+            save_run: boolean;
+            /**
+             * Start
+             * Format: date
+             * @description First date, YYYY-MM-DD.
+             */
+            start: string;
+            /**
+             * Ticker
+             * @description One ticker (or use --tickers for a comparison table).
+             */
+            ticker?: string | null;
+            /**
+             * Tickers
+             * @description Several tickers for a comparison table (or use --portfolio).
+             */
+            tickers?: string[] | null;
+        };
         /** FactorsParams */
         FactorsParams: {
             /**
@@ -1736,6 +1846,37 @@ export interface components {
             /** Value */
             value: string;
         };
+        /** StockParams */
+        StockParams: {
+            /**
+             * End
+             * @description Last date (default: today).
+             */
+            end?: string | null;
+            /**
+             * Fill
+             * @description Provider-gap policy: drop, ffill or raise. No default.
+             * @enum {string}
+             */
+            fill: "drop" | "ffill" | "raise";
+            /**
+             * Risk Free
+             * @description Annual decimal risk-free rate for the risk panel.
+             */
+            risk_free?: number | null;
+            /**
+             * Start
+             * Format: date
+             * @description First date, YYYY-MM-DD.
+             * @default 2015-01-01
+             */
+            start: string;
+            /**
+             * Ticker
+             * @description Ticker symbol, e.g. NVDA.
+             */
+            ticker: string;
+        };
         /** TokenRotateParams */
         TokenRotateParams: {
             /**
@@ -1836,6 +1977,72 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    analyze_factors_api_v1_analyze_factors_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FactorParams"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analyze_stock_api_v1_analyze_stock_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StockParams"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     login_api_v1_auth_login_post: {
         parameters: {
             query?: never;

--- a/openspec/changes/0007-equity-factor-analysis/design.md
+++ b/openspec/changes/0007-equity-factor-analysis/design.md
@@ -1,0 +1,54 @@
+# 0007 — Design
+
+## Regression on numpy, HAC by hand
+
+`statsmodels` stays in the `econ` extra. The OLS fit, classical standard errors
+and the Newey-West (Bartlett kernel) covariance are ~40 lines of numpy in
+`core/factors.py`, with the formulas cited in the module docstring. The test
+suite checks them against a hand-worked two-variable closed form and, as an
+independent implementation, against `statsmodels` HAC (`tests/core/test_factors.py`)
+— the reference is used by the tests, not by the product, so the base install
+gains no dependency. The lag length defaults to the Newey & West (1994) rule
+`floor(4 (n/100)^(2/9))` and is always stated in the output.
+
+## Excess returns, monthly by default
+
+The dependent variable is `r - RF` with `RF` from the same Ken French file — not
+the FRED bill used elsewhere — so an asset's alpha is measured against the
+factors' own zero. Monthly is the default frequency because that is how the
+factors are published: daily prices are resampled to month-end and simple
+monthly returns taken before alignment (`core/factors.py::to_monthly_returns`).
+`--frequency daily` uses the daily factor files.
+
+## Alpha, twice, and never alone
+
+Every term carries OLS and HAC standard errors, t and p. The significance
+statement uses the HAC p-value (the conservative one); when it exceeds 0.05
+the output says alpha is not statistically distinguishable from zero and that
+the point estimate should not be read on its own. The comparison table marks
+significant alphas with `*` and says what the absence of a mark means.
+
+## Fundamentals at the provider boundary
+
+`YahooSource` gains `fundamentals(ticker)` returning the vendor's `info`
+document (or None for ETFs, funds and indexes); `YFinanceProvider.get_fundamentals`
+parses the documented keys into a `Fundamentals` dataclass. Fundamentals are
+current values and are never cached as observations. The recorded fixture is
+`tests/fixtures/yfinance/fundamentals.json`, in the vendor's key names.
+
+## A cache bug this change found
+
+Cached factor frames came back with an empty `Mkt-RF` column: the observation
+cache upper-cased symbols before asking the provider, and the provider's
+mixed-case column was never stored. The cache now asks in the caller's casing,
+stores keys upper-cased, and restores the caller's casing on the way out
+(`tests/data/test_cache.py::test_mixed_case_symbols_round_trip_with_their_casing`).
+
+## Rejected
+
+| Choice | Rejected | Why |
+|---|---|---|
+| numpy OLS + HAC | `statsmodels` in the base install | ~80 MB of dependency for one covariance formula; the tests still use it as the oracle |
+| `RF` from the factor file | FRED bill | Would mix two risk-free series in one regression |
+| Monthly default | Daily default | Factors are monthly; daily fits over-weight microstructure noise |
+| Fundamentals uncached | Cache as observations | They are not time-series observations; caching would imply point-in-time values they are not |

--- a/openspec/changes/0007-equity-factor-analysis/proposal.md
+++ b/openspec/changes/0007-equity-factor-analysis/proposal.md
@@ -2,8 +2,8 @@
 change: 0007-equity-factor-analysis
 milestone: v1.3
 depends_on: [0001-foundation-data-and-cli, 0002-portfolio-optimization]
-status: proposed
-planning_depth: proposal + spec delta (design and tasks written when 0006 lands)
+status: implemented
+planning_depth: proposal + spec delta + design + tasks
 ---
 
 # 0007 — Equity and factor analysis

--- a/openspec/changes/0007-equity-factor-analysis/tasks.md
+++ b/openspec/changes/0007-equity-factor-analysis/tasks.md
@@ -1,0 +1,40 @@
+# 0007 — Tasks
+
+Each task names the test that proves it.
+
+## Wave A — core
+
+- [x] **A1. `core/factors.py`** — `factor_regression` (capm, ff3, ff5, ff5+mom) with
+      OLS and Newey-West statistics, annualized alpha, R² and adjusted R²; the
+      honesty statement; `rolling_loadings`; `capm_beta`; `to_monthly_returns`.
+      → `tests/core/test_factors.py` (closed form, statsmodels as the HAC oracle)
+- [x] **A2. Minimum sample** — 36 monthly / 252 daily from `core/conventions.py`;
+      the error names available and required counts.
+      → `tests/core/test_factors.py::test_minimum_sample_names_available_and_required`
+
+## Wave B — data
+
+- [x] **B1. Fundamentals** — `YahooSource.fundamentals`, `YFinanceProvider.get_fundamentals`,
+      the fixture source, `fundamentals.json` recorded/synthesized by the scripts.
+      → `tests/cli/test_analyze.py::test_missing_fundamentals_omits_the_block_and_keeps_the_rest`
+- [x] **B2. Cache casing fix** — mixed-case symbols round-trip with their values.
+      → `tests/data/test_cache.py::test_mixed_case_symbols_round_trip_with_their_casing`
+
+## Wave C — CLI
+
+- [x] **C1. `sobres analyze factors`** — one ticker, `--tickers`, or `--portfolio`;
+      `--model`, `--frequency` (monthly default), `--rolling`, `--hac-lags`.
+      → `tests/cli/test_analyze.py`
+- [x] **C2. `sobres analyze stock`** — price summary, annualized return and volatility,
+      the 0002 risk panel, CAPM beta, fundamentals with the point-in-time note.
+      → `tests/cli/test_analyze.py::test_stock_dashboard_has_every_section`
+- [x] **C3. Surfaces** — registry group, API route and UI view via the manifest.
+      → `tests/api/test_parity.py`, `tests/invariants/test_every_command.py`
+- [x] **C4. Docs** — README, CHANGELOG, design.
+
+## Verification note
+
+Ken French and Yahoo fixtures are synthesized (see `tests/fixtures/README.md`),
+so the numbers in the offline suite prove the plumbing and the statistics, not
+any real stock's exposures; the math is proved on constructed data with known
+answers.

--- a/scripts/record_fixtures.py
+++ b/scripts/record_fixtures.py
@@ -71,7 +71,7 @@ def record_yfinance(start: date, end: date) -> None:
         if info:
             fundamentals[ticker] = {k: info.get(k) for k in keys}
     (out / "fundamentals.json").write_text(
-        _meta("yfinance", provider_version=yf.__version__, tickers=fundamentals)
+        _meta("yfinance", provider_version=yf.__version__, tickers=fundamentals), encoding="utf-8"
     )
     (out / "meta.json").write_text(
         _meta("yfinance", provider_version=yf.__version__, tickers=tickers), encoding="utf-8"

--- a/scripts/record_fixtures.py
+++ b/scripts/record_fixtures.py
@@ -54,6 +54,25 @@ def record_yfinance(start: date, end: date) -> None:
         raw = source.history(ticker, start, end)
         raw.frame.round(6).to_csv(out / f"{ticker}.csv")
         tickers[ticker] = {k: raw.meta.get(k) for k in ("currency", "exchangeName", "symbol")}
+    keys = (
+        "quoteType",
+        "longName",
+        "shortName",
+        "sector",
+        "marketCap",
+        "trailingPE",
+        "priceToBook",
+        "dividendYield",
+        "currency",
+    )
+    fundamentals = {}
+    for ticker in TICKERS:
+        info = source.fundamentals(ticker)
+        if info:
+            fundamentals[ticker] = {k: info.get(k) for k in keys}
+    (out / "fundamentals.json").write_text(
+        _meta("yfinance", provider_version=yf.__version__, tickers=fundamentals)
+    )
     (out / "meta.json").write_text(
         _meta("yfinance", provider_version=yf.__version__, tickers=tickers)
     )

--- a/scripts/synthesize_fixtures.py
+++ b/scripts/synthesize_fixtures.py
@@ -101,6 +101,35 @@ def write_yfinance(rng: np.random.Generator) -> None:
             "exchangeName": "LSE" if currency == "GBp" else "NMS",
             "symbol": ticker,
         }
+    # Fundamentals (0007): the Ticker.info keys sobres reads, invented per ticker; ETFs have none.
+    fundamentals = {
+        t: {
+            "quoteType": "EQUITY",
+            "longName": f"{t} Inc.",
+            "sector": "Technology",
+            "marketCap": float(rng.integers(50, 3000)) * 1e9,
+            "trailingPE": round(float(rng.uniform(10, 60)), 1),
+            "priceToBook": round(float(rng.uniform(1, 50)), 1),
+            "dividendYield": round(float(dy), 4),
+            "currency": currency,
+        }
+        for t, (_, _, _, currency, dy) in TICKERS.items()
+        if t != "GLD"
+    }
+    (out / "fundamentals.json").write_text(
+        json.dumps(
+            {
+                "recorded_at": None,
+                "synthesized_at": datetime.now(UTC).isoformat(),
+                "provider": "yfinance",
+                "note": "synthesized in the shape of Ticker.info (the keys sobres reads); "
+                "GLD is an ETF and has none",
+                "tickers": fundamentals,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
     (out / "meta.json").write_text(
         json.dumps(
             {

--- a/scripts/synthesize_fixtures.py
+++ b/scripts/synthesize_fixtures.py
@@ -128,7 +128,8 @@ def write_yfinance(rng: np.random.Generator) -> None:
             },
             indent=2,
         )
-        + "\n"
+        + "\n",
+        encoding="utf-8",
     )
     (out / "meta.json").write_text(
         json.dumps(

--- a/src/sobres/cli/commands/__init__.py
+++ b/src/sobres/cli/commands/__init__.py
@@ -3,6 +3,7 @@
 import importlib
 
 MODULES: tuple[str, ...] = (
+    "analyze",
     "cache",
     "commands",
     "config",

--- a/src/sobres/cli/commands/analyze.py
+++ b/src/sobres/cli/commands/analyze.py
@@ -1,0 +1,382 @@
+"""``sobres analyze`` — a single-stock dashboard and factor-model regressions.
+
+Adapters only: prices come from the price provider, factors from the Ken
+French provider, the regression from ``core/factors.py``. Monthly is the
+default frequency because that is how the factors are published; the asset's
+daily prices are resampled to month-end before returns are taken, and the
+dependent variable is ``r - RF`` with ``RF`` from the same factor file.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, ClassVar, Literal
+
+import pandas as pd
+from pydantic import Field, model_validator
+
+from sobres.cli.commands.optimize import IN_SAMPLE_NOTE, UniverseParams, load_universe
+from sobres.cli.context import Context
+from sobres.core import factors as fm
+from sobres.core.returns import annualized_return, annualized_volatility, simple_returns
+from sobres.core.risk import risk_metrics
+from sobres.data.base import FactorModel
+from sobres.data.gaps import FillPolicy
+from sobres.data.yfinance_provider import FUNDAMENTALS_NOTE
+from sobres.registry import Currency, Params, Ticker, TickerList, positional, register
+from sobres.results import FrameResult, Provenance, RecordsResult, Result
+
+Frequency = Literal["monthly", "daily"]
+STAT_COLUMNS = ("coefficient", "se", "t", "p", "se_hac", "t_hac", "p_hac")
+
+
+def _returns_at(prices: pd.DataFrame, frequency: Frequency) -> pd.DataFrame:
+    if frequency == "monthly":
+        return pd.DataFrame(fm.to_monthly_returns(prices))
+    return pd.DataFrame(simple_returns(prices)).dropna(how="all")
+
+
+def _factors(
+    ctx: Context, model: str, frequency: Frequency, start: date, end: date
+) -> pd.DataFrame:
+    source: FactorModel = fm.MODEL_SOURCE[model]  # type: ignore[assignment]
+    return ctx.factor_provider().get_factors(source, frequency, start, end)
+
+
+# --------------------------------------------------------------------------- #
+# analyze factors
+# --------------------------------------------------------------------------- #
+
+
+class FactorParams(Params):
+    ticker: Ticker | None = positional(
+        default=None, description="One ticker (or use --tickers for a comparison table)."
+    )
+    tickers: TickerList | None = Field(
+        default=None, description="Several tickers for a comparison table (or use --portfolio)."
+    )
+    portfolio: str | None = Field(
+        default=None, description="A saved portfolio's name in place of --tickers."
+    )
+    save_run: bool = Field(default=False, description="Record this run in the run history.")
+    start: date = Field(description="First date, YYYY-MM-DD.")
+    end: date | None = Field(default=None, description="Last date (default: today).")
+    fill: FillPolicy = Field(description="Provider-gap policy: drop, ffill or raise. No default.")
+    base: Currency | None = Field(
+        default=None, description="Base currency for a multi-currency universe (e.g. USD)."
+    )
+    model: fm.Model = Field(default="ff3", description="Factor model.")
+    frequency: Frequency = Field(
+        default="monthly", description="Return frequency; monthly matches the published factors."
+    )
+    rolling: int | None = Field(
+        default=None,
+        ge=6,
+        description="Window (in periods) for rolling loadings instead of one fit.",
+    )
+    hac_lags: int | None = Field(
+        default=None,
+        ge=0,
+        description="Newey-West lag length; default: the Newey-West (1994) rule.",
+    )
+
+    @model_validator(mode="after")
+    def _one_universe(self) -> FactorParams:
+        given = [bool(self.ticker), bool(self.tickers), bool(self.portfolio)]
+        if sum(given) != 1:
+            raise ValueError("give exactly one of: a ticker, --tickers, or --portfolio")
+        if self.end is not None and self.end < self.start:
+            raise ValueError(f"end {self.end} precedes start {self.start}")
+        if self.rolling is not None and (self.tickers or self.portfolio):
+            raise ValueError("--rolling applies to a single ticker")
+        return self
+
+    @property
+    def universe(self) -> list[str]:
+        return [self.ticker] if self.ticker else list(self.tickers or [])
+
+
+class FactorReport(Result):
+    """Every factor result is a report: the disclaimer footer applies to all three shapes."""
+
+    report: ClassVar[bool] = True
+
+
+class FactorResult(FactorReport, RecordsResult):
+    """One ticker: a row per term (alpha first), the model statistics in the header."""
+
+    column_kinds: ClassVar[dict[str, str]] = {"term": "text"}
+    ticker: str
+    model: str
+    frequency: str
+    n_obs: int
+    r2: float
+    adj_r2: float
+    hac_lags: int
+    annualized_alpha: float
+    alpha_p_hac: float
+    alpha_statement: str
+
+    def header_lines(self) -> list[str]:
+        return [
+            f"{self.ticker}: {self.model} on {self.frequency} excess returns (r - RF from the "
+            f"factor file), {self.n_obs} observations",
+            f"R² {self.r2:.4f}, adjusted R² {self.adj_r2:.4f}; HAC (Newey-West) standard errors "
+            f"with {self.hac_lags} lag(s) reported beside OLS",
+            self.alpha_statement,
+            *super().header_lines(),
+        ]
+
+
+class FactorComparison(FactorReport, RecordsResult):
+    """Several tickers: one row each with loadings, alpha, its HAC t-statistic and R²."""
+
+    column_kinds: ClassVar[dict[str, str]] = {"ticker": "text"}
+    model: str
+    frequency: str
+    hac_lags: dict[str, int]
+
+    def header_lines(self) -> list[str]:
+        return [
+            f"{self.model} on {self.frequency} excess returns; rows in the order supplied; "
+            "alpha_t is the HAC t-statistic",
+            "alpha not marked * is not statistically distinguishable from zero at the 5% level",
+            *super().header_lines(),
+        ]
+
+
+class RollingLoadings(FactorReport, FrameResult):
+    ticker: str
+    model: str
+    window: int
+
+    def header_lines(self) -> list[str]:
+        return [
+            f"{self.ticker}: {self.model} loadings over each trailing {self.window}-period window",
+            *super().header_lines(),
+        ]
+
+
+def _term_rows(fit: fm.FactorRegression) -> list[dict[str, Any]]:
+    rows = [{"term": "alpha", **fit.alpha.as_dict(), "annualized": fit.annualized_alpha}]
+    for name, stats in fit.loadings.items():
+        rows.append({"term": name, **stats.as_dict(), "annualized": None})
+    return rows
+
+
+@register(
+    "analyze.factors",
+    "Regress excess returns on CAPM or Fama-French factors; alpha with its t-statistic.",
+    result=FactorReport,
+)
+def factors(p: FactorParams, ctx: Context) -> FactorReport:
+    universe = load_universe(
+        UniverseParams(
+            tickers=p.universe or None,
+            portfolio=p.portfolio,
+            start=p.start,
+            end=p.end,
+            fill=p.fill,
+            base=p.base,
+        ),
+        ctx,
+    )
+    if p.portfolio:
+        p = p.model_copy(update={"tickers": list(universe.prices.columns)})
+    end = p.end or ctx.today()
+    factor_frame = _factors(ctx, p.model, p.frequency, p.start, end)
+    returns = _returns_at(universe.prices, p.frequency)
+    provenance = Provenance.from_attrs(
+        universe.prices.attrs,
+        start=str(returns.index.min().date()),
+        end=str(returns.index.max().date()),
+        notes=[
+            f"factors: Ken French {fm.MODEL_SOURCE[p.model]} ({p.frequency}); "
+            "RF from the same file",
+            IN_SAMPLE_NOTE,
+        ],
+    )
+    provenance.currency = universe.currency
+    if p.rolling is not None:
+        ticker = p.universe[0]
+        frame = fm.rolling_loadings(
+            returns[ticker], factor_frame, p.model, window=p.rolling, frequency=p.frequency
+        )
+        return RollingLoadings(
+            frame=frame, ticker=ticker, model=p.model, window=p.rolling, provenance=provenance
+        )
+    fits = {
+        ticker: fm.factor_regression(
+            returns[ticker], factor_frame, p.model, frequency=p.frequency, hac_lags=p.hac_lags
+        )
+        for ticker in p.universe
+    }
+    if len(fits) == 1:
+        ticker, fit = next(iter(fits.items()))
+        provenance.start, provenance.end = str(fit.start.date()), str(fit.end.date())
+        return FactorResult(
+            rows=_term_rows(fit),
+            columns=["term", *STAT_COLUMNS, "annualized"],
+            ticker=ticker,
+            model=p.model,
+            frequency=p.frequency,
+            n_obs=fit.n_obs,
+            r2=fit.r2,
+            adj_r2=fit.adj_r2,
+            hac_lags=fit.hac_lags,
+            annualized_alpha=fit.annualized_alpha,
+            alpha_p_hac=fit.alpha.p_hac,
+            alpha_statement=fit.alpha_statement,
+            provenance=provenance,
+        )
+    loadings = list(fm.factor_columns(p.model))
+    rows = []
+    for ticker in p.universe:  # the order supplied, so output diffs across runs
+        fit = fits[ticker]
+        rows.append(
+            {
+                "ticker": ticker,
+                **{name: fit.loadings[name].coefficient for name in loadings},
+                "alpha_annualized": fit.annualized_alpha,
+                "alpha_t": fit.alpha.t_hac,
+                "alpha_p": fit.alpha.p_hac,
+                "significant": "*" if fit.alpha_significant else "",
+                "r2": fit.r2,
+                "n_obs": fit.n_obs,
+            }
+        )
+    return FactorComparison(
+        rows=rows,
+        columns=[
+            "ticker",
+            *loadings,
+            "alpha_annualized",
+            "alpha_t",
+            "alpha_p",
+            "significant",
+            "r2",
+            "n_obs",
+        ],
+        model=p.model,
+        frequency=p.frequency,
+        hac_lags={t: f.hac_lags for t, f in fits.items()},
+        provenance=provenance,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# analyze stock
+# --------------------------------------------------------------------------- #
+
+
+class StockParams(Params):
+    ticker: Ticker = positional(description="Ticker symbol, e.g. NVDA.")
+    start: date = Field(default=date(2015, 1, 1), description="First date, YYYY-MM-DD.")
+    end: date | None = Field(default=None, description="Last date (default: today).")
+    fill: FillPolicy = Field(description="Provider-gap policy: drop, ffill or raise. No default.")
+    risk_free: float | None = Field(
+        default=None, description="Annual decimal risk-free rate for the risk panel."
+    )
+
+
+class StockReport(RecordsResult):
+    """Sections of metric/value rows: price, returns, risk, CAPM, fundamentals."""
+
+    report: ClassVar[bool] = True
+    column_kinds: ClassVar[dict[str, str]] = {"section": "text", "metric": "text"}
+    ticker: str
+    name: str | None
+    fundamentals_note: str
+
+    def header_lines(self) -> list[str]:
+        title = f"{self.ticker}" + (f" — {self.name}" if self.name else "")
+        return [title, self.fundamentals_note, *super().header_lines()]
+
+
+def _rows(section: str, items: dict[str, Any]) -> list[dict[str, Any]]:
+    return [{"section": section, "metric": k, "value": v} for k, v in items.items()]
+
+
+@register(
+    "analyze.stock",
+    "Price summary, risk panel, CAPM beta and fundamentals for one stock.",
+    result=StockReport,
+)
+def stock(p: StockParams, ctx: Context) -> StockReport:
+    universe = load_universe(
+        UniverseParams(
+            tickers=[p.ticker], start=p.start, end=p.end, fill=p.fill, risk_free=p.risk_free
+        ),
+        ctx,
+    )
+    prices = universe.prices[p.ticker]
+    daily = universe.returns[p.ticker]
+    panel = risk_metrics(daily, universe.risk_free, universe.frequency)
+    rows = _rows(
+        "price",
+        {
+            "first": float(prices.iloc[0]),
+            "last": float(prices.iloc[-1]),
+            "high": float(prices.max()),
+            "low": float(prices.min()),
+            "period_return": float(prices.iloc[-1] / prices.iloc[0] - 1.0),
+            "currency": universe.currency,
+        },
+    )
+    rows += _rows(
+        "returns",
+        {
+            "annualized_return": annualized_return(daily, universe.frequency),
+            "annualized_volatility": annualized_volatility(daily, universe.frequency),
+            "n_obs": len(daily),
+        },
+    )
+    rows += _rows("risk", {k: v for k, v in panel.as_dict().items() if k not in ("frequency",)})
+    notes = [f"risk-free rate {universe.risk_free:.4%} ({universe.risk_free_source})"]
+    end = p.end or ctx.today()
+    try:
+        factor_frame = _factors(ctx, "capm", "monthly", p.start, end)
+        monthly = fm.to_monthly_returns(prices)
+        fit = fm.factor_regression(pd.Series(monthly), factor_frame, "capm", frequency="monthly")
+        rows += _rows(
+            "capm",
+            {
+                "beta_mkt": fit.loadings["Mkt-RF"].coefficient,
+                "beta_t_hac": fit.loadings["Mkt-RF"].t_hac,
+                "alpha_annualized": fit.annualized_alpha,
+                "alpha_p_hac": fit.alpha.p_hac,
+                "r2": fit.r2,
+                "n_months": fit.n_obs,
+            },
+        )
+        notes.append(f"capm: {fit.alpha_statement}")
+    except Exception as exc:  # the price and risk sections still render
+        ctx.log.warning("capm.skipped", symbol=p.ticker, reason=f"{type(exc).__name__}: {exc}")
+        notes.append(f"capm: not estimated ({exc})")
+    fundamentals = ctx.price_provider().get_fundamentals(p.ticker)  # type: ignore[attr-defined]
+    name: str | None = None
+    if fundamentals is None:
+        note = f"fundamentals: none reported for {p.ticker} (common for ETFs); section omitted"
+    else:
+        name = fundamentals.name
+        rows += _rows(
+            "fundamentals",
+            {
+                "market_cap": fundamentals.market_cap,
+                "pe_ratio": fundamentals.pe_ratio,
+                "price_to_book": fundamentals.price_to_book,
+                "dividend_yield": fundamentals.dividend_yield,
+                "sector": fundamentals.sector,
+            },
+        )
+        note = FUNDAMENTALS_NOTE
+    provenance = universe.provenance
+    provenance.notes = [*notes, *provenance.notes]
+    return StockReport(
+        rows=rows,
+        columns=["section", "metric", "value"],
+        ticker=p.ticker,
+        name=name,
+        fundamentals_note=note,
+        provenance=provenance,
+    )

--- a/src/sobres/core/factors.py
+++ b/src/sobres/core/factors.py
@@ -1,0 +1,265 @@
+"""Factor-model regressions: CAPM, Fama-French three and five factors, plus momentum.
+
+The question these answer: is an asset's excess return explained by known risk
+factors, or is there alpha — and is that alpha distinguishable from zero? So
+every coefficient comes with its standard error, t-statistic and p-value, and
+alpha comes twice: under classical OLS standard errors and under Newey-West
+(HAC) standard errors that survive autocorrelated, heteroskedastic residuals.
+
+Math (Fama & French 1993, 2015; Carhart 1997 for momentum; Newey & West 1987):
+
+    r_i,t - RF_t = alpha + sum_k beta_k F_k,t + e_t              (OLS by least squares)
+    Var_OLS(b)   = s^2 (X'X)^-1,  s^2 = e'e / (n - k)
+    Var_HAC(b)   = (X'X)^-1 [ S_0 + sum_{l=1}^{L} w_l (S_l + S_l') ] (X'X)^-1,
+                   S_l = sum_t x_t e_t e_{t-l} x_{t-l}',  w_l = 1 - l/(L+1)   (Bartlett kernel)
+    L            = floor(4 (n/100)^(2/9))                          (Newey & West 1994 rule)
+    t = b / se,  p = 2 (1 - T_{n-k}(|t|)),  annualized alpha = (1 + alpha)^periods - 1
+
+Pure functions over frames; no I/O, no logging.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from sobres.core.conventions import PERIODS_PER_YEAR, periods_per_year
+from sobres.core.errors import InsufficientDataError, UsageError
+
+Model = Literal["capm", "ff3", "ff5", "ff5+mom"]
+MODELS: tuple[str, ...] = ("capm", "ff3", "ff5", "ff5+mom")
+MODEL_FACTORS: dict[str, tuple[str, ...]] = {
+    "capm": ("Mkt-RF",),
+    "ff3": ("Mkt-RF", "SMB", "HML"),
+    "ff5": ("Mkt-RF", "SMB", "HML", "RMW", "CMA"),
+    "ff5+mom": ("Mkt-RF", "SMB", "HML", "RMW", "CMA", "MOM"),
+}
+# The factor file each model's columns come from (the data layer fetches by this).
+MODEL_SOURCE: dict[str, str] = {"capm": "ff3", "ff3": "ff3", "ff5": "ff5", "ff5+mom": "ff5+mom"}
+RISK_FREE_COLUMN = "RF"
+SIGNIFICANCE = 0.05
+# Three years of monthly observations, or one year of daily ones.
+MIN_OBS: dict[str, int] = {
+    "monthly": 3 * PERIODS_PER_YEAR["monthly"],
+    "daily": PERIODS_PER_YEAR["daily"],
+}
+ALPHA_NOT_DISTINGUISHABLE = "alpha is not statistically distinguishable from zero at the 5% level"
+
+
+@dataclass(frozen=True)
+class CoefficientStats:
+    """One regression term under classical and HAC standard errors."""
+
+    coefficient: float
+    se: float
+    t: float
+    p: float
+    se_hac: float
+    t_hac: float
+    p_hac: float
+
+    def as_dict(self) -> dict[str, float]:
+        return dict(self.__dict__)
+
+
+@dataclass(frozen=True)
+class FactorRegression:
+    model: str
+    frequency: str
+    n_obs: int
+    start: pd.Timestamp
+    end: pd.Timestamp
+    alpha: CoefficientStats
+    annualized_alpha: float
+    loadings: dict[str, CoefficientStats]
+    r2: float
+    adj_r2: float
+    hac_lags: int
+    residuals: pd.Series = field(repr=False, compare=False)
+
+    @property
+    def alpha_significant(self) -> bool:
+        """Under the HAC standard error — the conservative one."""
+        return self.alpha.p_hac <= SIGNIFICANCE
+
+    @property
+    def alpha_statement(self) -> str:
+        if self.alpha_significant:
+            return (
+                f"alpha {self.annualized_alpha:.4%} annualized is distinguishable from zero at "
+                f"the 5% level (HAC t = {self.alpha.t_hac:.2f}, p = {self.alpha.p_hac:.3f})"
+            )
+        return (
+            f"{ALPHA_NOT_DISTINGUISHABLE} (HAC t = {self.alpha.t_hac:.2f}, "
+            f"p = {self.alpha.p_hac:.3f}); the point estimate {self.annualized_alpha:.4%} "
+            "annualized should not be read on its own"
+        )
+
+
+def newey_west_lags(n_obs: int) -> int:
+    """Newey & West (1994) automatic bandwidth: floor(4 (n/100)^(2/9))."""
+    return int(np.floor(4.0 * (n_obs / 100.0) ** (2.0 / 9.0)))
+
+
+def factor_columns(model: str) -> tuple[str, ...]:
+    if model not in MODEL_FACTORS:
+        raise UsageError(f"model must be one of {', '.join(MODELS)}, got {model!r}")
+    return MODEL_FACTORS[model]
+
+
+def excess_returns(returns: pd.Series, factors: pd.DataFrame) -> pd.Series:
+    """``r - RF`` on the inner join of the two indexes; RF comes from the factor file."""
+    if RISK_FREE_COLUMN not in factors.columns:
+        raise UsageError(f"the factor frame has no {RISK_FREE_COLUMN} column")
+    both = pd.concat([returns.rename("__r__"), factors[RISK_FREE_COLUMN]], axis=1, join="inner")
+    both = both.dropna()
+    out = both["__r__"] - both[RISK_FREE_COLUMN]
+    out.name = returns.name
+    return out
+
+
+def _design(excess: pd.Series, factors: pd.DataFrame, columns: tuple[str, ...]) -> pd.DataFrame:
+    frame = pd.concat([excess.rename("__y__"), factors[list(columns)]], axis=1, join="inner")
+    return frame.dropna()
+
+
+def _ols_with_hac(
+    y: np.ndarray, x: np.ndarray, lags: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, float]:
+    """Coefficients, OLS se, HAC se, residuals, R², adjusted R²."""
+    n, k = x.shape
+    xtx_inv = np.linalg.inv(x.T @ x)
+    beta = xtx_inv @ x.T @ y
+    resid = y - x @ beta
+    dof = n - k
+    s2 = float(resid @ resid) / dof
+    se_ols = np.sqrt(np.diag(s2 * xtx_inv))
+    scores = x * resid[:, None]  # x_t e_t, one row per observation
+    s = scores.T @ scores
+    for lag in range(1, lags + 1):
+        w = 1.0 - lag / (lags + 1.0)
+        gamma = scores[lag:].T @ scores[:-lag]
+        s += w * (gamma + gamma.T)
+    cov_hac = xtx_inv @ s @ xtx_inv
+    se_hac = np.sqrt(np.diag(cov_hac))
+    tss = float(((y - y.mean()) ** 2).sum())
+    r2 = 1.0 - float(resid @ resid) / tss if tss > 0 else float("nan")
+    adj_r2 = 1.0 - (1.0 - r2) * (n - 1) / dof if tss > 0 else float("nan")
+    return beta, se_ols, se_hac, resid, r2, adj_r2
+
+
+def _stats(coef: float, se: float, se_hac: float, dof: int) -> CoefficientStats:
+    t = coef / se if se > 0 else float("inf")
+    t_hac = coef / se_hac if se_hac > 0 else float("inf")
+    p = float(2.0 * stats.t.sf(abs(t), dof)) if np.isfinite(t) else 0.0
+    p_hac = float(2.0 * stats.t.sf(abs(t_hac), dof)) if np.isfinite(t_hac) else 0.0
+    return CoefficientStats(float(coef), float(se), float(t), p, float(se_hac), float(t_hac), p_hac)
+
+
+def factor_regression(
+    returns: pd.Series,
+    factors: pd.DataFrame,
+    model: Model | str = "ff3",
+    *,
+    frequency: str = "monthly",
+    hac_lags: int | None = None,
+    min_obs: int | None = None,
+) -> FactorRegression:
+    """Regress ``returns - RF`` on the model's factors with OLS and HAC inference.
+
+    ``returns`` are simple periodic returns at ``frequency``; ``factors`` is the
+    Ken French frame at the same frequency (decimal returns, ``RF`` included).
+    Raises ``InsufficientDataError`` below ``MIN_OBS[frequency]`` observations.
+    """
+    columns = factor_columns(model)
+    missing = [c for c in columns if c not in factors.columns]
+    if missing:
+        raise UsageError(f"factor frame lacks {', '.join(missing)} needed by {model}")
+    excess = excess_returns(returns, factors)
+    frame = _design(excess, factors, columns)
+    required = MIN_OBS.get(frequency, MIN_OBS["monthly"]) if min_obs is None else min_obs
+    if len(frame) < required:
+        raise InsufficientDataError(
+            f"{len(frame)} {frequency} observations available, {required} required for a "
+            f"{model} regression",
+            hint="widen --start/--end, or use --frequency daily for a short history",
+        )
+    y = frame["__y__"].to_numpy(dtype="float64")
+    x = np.column_stack([np.ones(len(frame)), frame[list(columns)].to_numpy(dtype="float64")])
+    lags = newey_west_lags(len(frame)) if hac_lags is None else int(hac_lags)
+    beta, se, se_hac, resid, r2, adj_r2 = _ols_with_hac(y, x, lags)
+    dof = len(frame) - x.shape[1]
+    alpha = _stats(beta[0], se[0], se_hac[0], dof)
+    loadings = {
+        name: _stats(beta[i + 1], se[i + 1], se_hac[i + 1], dof) for i, name in enumerate(columns)
+    }
+    periods = periods_per_year(frequency)
+    return FactorRegression(
+        model=model,
+        frequency=frequency,
+        n_obs=len(frame),
+        start=pd.Timestamp(frame.index.min()),
+        end=pd.Timestamp(frame.index.max()),
+        alpha=alpha,
+        annualized_alpha=float((1.0 + alpha.coefficient) ** periods - 1.0),
+        loadings=loadings,
+        r2=r2,
+        adj_r2=adj_r2,
+        hac_lags=lags,
+        residuals=pd.Series(resid, index=frame.index, name="residual"),
+    )
+
+
+def rolling_loadings(
+    returns: pd.Series,
+    factors: pd.DataFrame,
+    model: Model | str = "ff3",
+    *,
+    window: int,
+    frequency: str = "monthly",
+) -> pd.DataFrame:
+    """Factor loadings (and alpha) re-estimated over each trailing ``window`` of periods.
+
+    One row per window end; exposure instability is visible rather than averaged
+    away. Raises ``InsufficientDataError`` when fewer than ``window`` observations exist.
+    """
+    columns = factor_columns(model)
+    excess = excess_returns(returns, factors)
+    frame = _design(excess, factors, columns)
+    if window < len(columns) + 2:
+        raise UsageError(f"--rolling must be at least {len(columns) + 2} for {model}")
+    if len(frame) < window:
+        raise InsufficientDataError(
+            f"{len(frame)} {frequency} observations available, {window} required for one window",
+            hint="shorten --rolling or widen --start/--end",
+        )
+    rows: list[dict[str, float]] = []
+    index: list[pd.Timestamp] = []
+    for end in range(window, len(frame) + 1):
+        piece = frame.iloc[end - window : end]
+        y = piece["__y__"].to_numpy(dtype="float64")
+        x = np.column_stack([np.ones(window), piece[list(columns)].to_numpy(dtype="float64")])
+        beta = np.linalg.lstsq(x, y, rcond=None)[0]
+        loadings = {c: float(beta[i + 1]) for i, c in enumerate(columns)}
+        rows.append({"alpha": float(beta[0]), **loadings})
+        index.append(pd.Timestamp(piece.index[-1]))
+    out = pd.DataFrame(rows, index=pd.DatetimeIndex(index, name="date"))
+    out.attrs = {"model": model, "window": window, "frequency": frequency}
+    return out
+
+
+def capm_beta(returns: pd.Series, factors: pd.DataFrame, *, frequency: str = "monthly") -> float:
+    """The market loading from a CAPM regression on excess returns."""
+    fit = factor_regression(returns, factors, "capm", frequency=frequency)
+    return fit.loadings["Mkt-RF"].coefficient
+
+
+def to_monthly_returns(prices: pd.Series | pd.DataFrame) -> pd.Series | pd.DataFrame:
+    """Month-end prices → simple monthly returns, aligned with how the factors are published."""
+    monthly = prices.resample("ME").last()
+    out = monthly.pct_change().dropna(how="all")
+    return out

--- a/src/sobres/data/cache.py
+++ b/src/sobres/data/cache.py
@@ -120,7 +120,9 @@ class ObservationCache:
         started = time.perf_counter()
         now = self._clock()
         requested = DateRange(start, end)
-        symbols = [s.upper() for s in symbols]
+        # Keys are stored upper-cased; the caller's casing (``Mkt-RF``) is restored on the way out.
+        casing = {s.upper(): s for s in symbols}
+        symbols = list(casing)
         to_fetch: dict[DateRange, list[str]] = {}
         for symbol in symbols:
             key = SeriesKey(provider, dataset, symbol)
@@ -144,7 +146,11 @@ class ObservationCache:
             {"provider": provider, "dataset": dataset, "symbols": len(symbols), "status": status},
         ) as sp:
             for rng, missing in sorted(to_fetch.items()):
-                frame = fetch(missing, rng.start, rng.end)
+                frame = fetch([casing[s] for s in missing], rng.start, rng.end)
+                frame = frame.rename(columns={casing[s]: s for s in missing})
+                frame.attrs["series_meta"] = {
+                    str(k).upper(): v for k, v in frame.attrs.get("series_meta", {}).items()
+                }
                 rows = self._to_observations(provider, dataset, frame, missing)
                 ttl = ttl_for(dataset, rng.end, now.date())
                 self._store.upsert_observations(rows)
@@ -160,9 +166,9 @@ class ObservationCache:
             result = self._store.read_observations(
                 ObservationQuery(provider, dataset, symbols, start, end)
             )
-            result = canonical_frame(result, symbols)
+            result = canonical_frame(result, symbols).rename(columns=casing)
             series_meta_all = {
-                s: m
+                casing[s]: m
                 for s in symbols
                 if (m := self._store.get_series_meta(SeriesKey(provider, dataset, s)))
             }

--- a/src/sobres/data/fixtures.py
+++ b/src/sobres/data/fixtures.py
@@ -42,7 +42,7 @@ class FixtureYahooSource:
         path = self.root / "fundamentals.json"
         if not path.exists():
             return None
-        docs = json.loads(path.read_text()).get("tickers", {})
+        docs = json.loads(path.read_text(encoding="utf-8")).get("tickers", {})
         info = docs.get(ticker.upper())
         return dict(info) if info else None
 

--- a/src/sobres/data/fixtures.py
+++ b/src/sobres/data/fixtures.py
@@ -37,6 +37,15 @@ class FixtureYahooSource:
         meta = dict(meta_all.get("tickers", {}).get(ticker.upper(), {}))
         return RawHistory(frame=frame, currency=meta.get("currency"), meta=meta)
 
+    def fundamentals(self, ticker: str) -> dict[str, Any] | None:
+        """``<dir>/yfinance/fundamentals.json``: symbol → the vendor's ``info`` keys we use."""
+        path = self.root / "fundamentals.json"
+        if not path.exists():
+            return None
+        docs = json.loads(path.read_text()).get("tickers", {})
+        info = docs.get(ticker.upper())
+        return dict(info) if info else None
+
 
 class FixtureFredSource:
     """``<dir>/fred/<SERIES>.json`` — the API's JSON response body."""

--- a/src/sobres/data/yfinance_provider.py
+++ b/src/sobres/data/yfinance_provider.py
@@ -52,8 +52,35 @@ class RawHistory:
     meta: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class Fundamentals:
+    """Current (not point-in-time) fundamentals for one symbol, as the vendor reports them."""
+
+    symbol: str
+    name: str | None
+    sector: str | None
+    market_cap: float | None
+    pe_ratio: float | None
+    price_to_book: float | None
+    dividend_yield: float | None
+    currency: str | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return dict(self.__dict__)
+
+
+FUNDAMENTALS_NOTE = (
+    "fundamentals are current values as the vendor reports them today, not point-in-time; "
+    "they are unsuitable for backtesting"
+)
+
+
 class YahooSource(Protocol):
     def history(self, ticker: str, start: date, end: date) -> RawHistory: ...
+
+    def fundamentals(self, ticker: str) -> dict[str, Any] | None:
+        """The vendor's ``info`` document, or None when it has none (common for ETFs)."""
+        ...
 
 
 class LiveYahooSource:
@@ -87,6 +114,25 @@ class LiveYahooSource:
             ) from exc
         currency = meta.get("currency")
         return RawHistory(frame=frame, currency=currency, meta=meta)
+
+    def fundamentals(self, ticker: str) -> dict[str, Any] | None:
+        try:
+            import yfinance as yf
+        except ImportError as exc:  # pragma: no cover - the [data] extra installs it
+            raise ProviderError(
+                "yfinance is not installed",
+                provider=PROVIDER_NAME,
+                hint="run: pip install 'sobres[data]'",
+            ) from exc
+        try:
+            info = dict(yf.Ticker(ticker).info or {})
+        except Exception as exc:
+            raise ProviderError(
+                f"{type(exc).__name__}: {exc}",
+                provider=PROVIDER_NAME,
+                hint="check the symbol and your network, or retry later",
+            ) from exc
+        return info if info.get("quoteType") not in (None, "ETF", "MUTUALFUND", "INDEX") else None
 
 
 class YFinanceProvider:
@@ -154,6 +200,15 @@ class YFinanceProvider:
         frame.attrs["flags"] = flags
         return frame
 
+    def get_fundamentals(self, ticker: str) -> Fundamentals | None:
+        """Current fundamentals, or None when the vendor has none for the symbol."""
+        with span("provider.get_fundamentals", {"provider": self.name, "symbol": ticker}):
+            info = self._source.fundamentals(ticker)
+        if not info:
+            self._log.info("fundamentals.missing", symbol=ticker)
+            return None
+        return parse_fundamentals(ticker, info)
+
     def _fetch(self, symbols: Sequence[str], start: date, end: date, field: str) -> pd.DataFrame:
         columns: dict[str, pd.Series] = {}
         series_meta: dict[str, dict[str, Any]] = {}
@@ -207,3 +262,22 @@ class YFinanceProvider:
             series_meta.setdefault(flag["symbol"], {}).setdefault("flags", []).append(flag)
         frame.attrs["series_meta"] = series_meta
         return frame
+
+
+def parse_fundamentals(symbol: str, info: dict[str, Any]) -> Fundamentals:
+    """Pick the documented keys out of the vendor's ``info`` document; absent keys stay None."""
+
+    def num(key: str) -> float | None:
+        value = info.get(key)
+        return float(value) if isinstance(value, int | float) and value == value else None
+
+    return Fundamentals(
+        symbol=symbol.upper(),
+        name=info.get("longName") or info.get("shortName"),
+        sector=info.get("sector"),
+        market_cap=num("marketCap"),
+        pe_ratio=num("trailingPE"),
+        price_to_book=num("priceToBook"),
+        dividend_yield=num("dividendYield"),
+        currency=info.get("currency"),
+    )

--- a/src/sobres/registry.py
+++ b/src/sobres/registry.py
@@ -148,6 +148,7 @@ GROUP_HELP: dict[str, str] = {
     "db": "Inspect, back up and repair the database.",
     "token": "Manage the deployment token.",
     "deploy": "Generate and check the container deployment.",
+    "analyze": "Single-stock dashboards and factor-model regressions.",
 }
 
 

--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -1,0 +1,154 @@
+"""``sobres analyze stock`` and ``sobres analyze factors`` end to end, offline.
+
+Scenarios: Default frequency; Stock dashboard; Fundamentals limitation is
+stated; Missing fundamentals; Comparison table; Rolling betas; Alpha is
+reported honestly; Robust standard errors; Minimum sample.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+WINDOW = ["--start", "2015-01-01", "--end", "2024-12-31", "--fill", "drop"]
+
+
+def _json(result: Any) -> dict[str, Any]:
+    assert result.exit_code == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_stock_dashboard_has_every_section(cli: Callable[..., Any]) -> None:
+    doc = _json(cli("analyze", "stock", "AAPL", *WINDOW, "--format", "json"))
+    sections = {(r["section"], r["metric"]): r["value"] for r in doc["rows"]}
+    for key in (("price", "first"), ("price", "last"), ("price", "high"), ("price", "low")):
+        assert key in sections
+    assert ("returns", "annualized_return") in sections
+    assert ("returns", "annualized_volatility") in sections
+    for metric in ("sharpe", "sortino", "max_drawdown", "var_95", "cvar_95", "skew", "kurtosis"):
+        assert ("risk", metric) in sections, metric  # the full 0002 panel
+    assert ("capm", "beta_mkt") in sections and sections[("capm", "n_months")] >= 36
+    for metric in ("market_cap", "pe_ratio", "price_to_book", "dividend_yield", "sector"):
+        assert ("fundamentals", metric) in sections, metric
+    assert sections[("fundamentals", "sector")] == "Technology"
+    assert doc["ticker"] == "AAPL" and doc["name"] == "Apple Inc."
+    table = cli("analyze", "stock", "AAPL", *WINDOW, "--format", "table")
+    assert "AAPL — Apple Inc." in table.stdout
+    assert "Not investment advice" in table.stdout
+
+
+def test_fundamentals_limitation_is_stated_whenever_values_show(cli: Callable[..., Any]) -> None:
+    table = cli("analyze", "stock", "MSFT", *WINDOW, "--format", "table")
+    assert "not point-in-time" in table.stdout and "unsuitable for backtesting" in table.stdout
+    doc = _json(cli("analyze", "stock", "MSFT", *WINDOW, "--format", "json"))
+    assert "not point-in-time" in doc["fundamentals_note"]
+
+
+def test_missing_fundamentals_omits_the_block_and_keeps_the_rest(cli: Callable[..., Any]) -> None:
+    doc = _json(cli("analyze", "stock", "GLD", *WINDOW, "--format", "json"))  # an ETF
+    sections = {r["section"] for r in doc["rows"]}
+    assert "fundamentals" not in sections and {"price", "returns", "risk"} <= sections
+    assert "none reported for GLD" in doc["fundamentals_note"] and "ETF" in doc["fundamentals_note"]
+    table = cli("analyze", "stock", "GLD", *WINDOW, "--format", "table")
+    assert "section omitted" in table.stdout and "max_drawdown" in table.stdout
+
+
+def test_default_frequency_is_monthly_and_daily_is_a_choice(cli: Callable[..., Any]) -> None:
+    doc = _json(cli("analyze", "factors", "AAPL", "--model", "ff5", *WINDOW, "--format", "json"))
+    assert doc["frequency"] == "monthly" and 100 <= doc["n_obs"] <= 120
+    assert [r["term"] for r in doc["rows"]] == ["alpha", "Mkt-RF", "SMB", "HML", "RMW", "CMA"]
+    for row in doc["rows"]:
+        for column in ("coefficient", "se", "t", "p", "se_hac", "t_hac", "p_hac"):
+            assert column in row, column  # Reported statistics, under OLS and HAC
+    assert doc["rows"][0]["annualized"] == doc["annualized_alpha"]
+    assert doc["hac_lags"] == 4  # floor(4 (119/100)^(2/9)); stated in the header
+    table = cli("analyze", "factors", "AAPL", "--model", "ff5", *WINDOW, "--format", "table")
+    assert "HAC (Newey-West) standard errors with 4 lag(s)" in table.stdout
+    assert "R²" in table.stdout and "adjusted R²" in table.stdout
+    daily = _json(
+        cli("analyze", "factors", "AAPL", "--frequency", "daily", *WINDOW, "--format", "json")
+    )
+    assert daily["frequency"] == "daily" and daily["n_obs"] > 2000
+
+
+def test_alpha_is_qualified_when_not_distinguishable_from_zero(cli: Callable[..., Any]) -> None:
+    table = cli("analyze", "factors", "AAPL", "--model", "ff3", *WINDOW, "--format", "table")
+    doc = _json(cli("analyze", "factors", "AAPL", "--model", "ff3", *WINDOW, "--format", "json"))
+    if doc["alpha_p_hac"] > 0.05:
+        assert "not statistically distinguishable from zero at the 5% level" in table.stdout
+        assert "should not be read on its own" in table.stdout
+    else:
+        assert "distinguishable from zero at the 5% level" in table.stdout
+
+
+def test_comparison_table_keeps_the_supplied_order(cli: Callable[..., Any]) -> None:
+    doc = _json(
+        cli(
+            "analyze",
+            "factors",
+            "--tickers",
+            "MSFT",
+            "GLD",
+            "AAPL",
+            "--model",
+            "ff5",
+            *WINDOW,
+            "--format",
+            "json",
+        )
+    )
+    assert [r["ticker"] for r in doc["rows"]] == ["MSFT", "GLD", "AAPL"]
+    assert doc["columns"][:6] == ["ticker", "Mkt-RF", "SMB", "HML", "RMW", "CMA"]
+    for row in doc["rows"]:
+        assert {"alpha_annualized", "alpha_t", "alpha_p", "r2", "n_obs"} <= set(row)
+        assert row["significant"] in ("", "*")
+    csv = cli(
+        "analyze",
+        "factors",
+        "--tickers",
+        "MSFT",
+        "GLD",
+        "AAPL",
+        "--model",
+        "ff5",
+        *WINDOW,
+        "--format",
+        "csv",
+    )
+    assert csv.stdout.splitlines()[1].startswith("MSFT,")
+
+
+def test_rolling_betas_are_a_frame_per_window(cli: Callable[..., Any]) -> None:
+    doc = _json(cli("analyze", "factors", "AAPL", "--rolling", "36", *WINDOW, "--format", "json"))
+    assert doc["columns"] == ["alpha", "Mkt-RF", "SMB", "HML"] and doc["window"] == 36
+    assert len(doc["rows"]) >= 80 and doc["rows"][0]["index"].startswith("2018-01")
+    bad = cli("analyze", "factors", "--tickers", "AAPL", "MSFT", "--rolling", "36", *WINDOW)
+    assert bad.exit_code == 2 and "single ticker" in bad.stderr
+
+
+def test_minimum_sample_is_an_insufficient_data_error(cli: Callable[..., Any]) -> None:
+    short = cli(
+        "analyze",
+        "factors",
+        "AAPL",
+        "--start",
+        "2023-01-01",
+        "--end",
+        "2024-12-31",
+        "--fill",
+        "drop",
+    )
+    assert short.exit_code == 5
+    assert "monthly observations available, 36 required" in short.stderr
+
+
+def test_exactly_one_universe_form(cli: Callable[..., Any]) -> None:
+    neither = cli("analyze", "factors", *WINDOW)
+    assert neither.exit_code == 2 and "exactly one of" in neither.stderr
+    both = cli("analyze", "factors", "AAPL", "--tickers", "MSFT", *WINDOW)
+    assert both.exit_code == 2
+    saved = cli("portfolio", "save", "core", "--tickers", "AAPL", "MSFT")
+    assert saved.exit_code == 0
+    doc = _json(cli("analyze", "factors", "--portfolio", "core", *WINDOW, "--format", "json"))
+    assert [r["ticker"] for r in doc["rows"]] == ["AAPL", "MSFT"]

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -29,9 +29,9 @@ def test_bare_shows_help_exit_0(cli: Callable[..., Any]) -> None:
 
 def test_help_lists_exactly_the_shipped_groups(cli: Callable[..., Any]) -> None:
     result = cli("--help")
-    for group in ("data", "cache", "config", "optimize"):
+    for group in ("data", "cache", "config", "optimize", "analyze"):
         assert f"\n  {group} " in result.output
-    assert "analyze" not in result.output
+    assert "\n  plan " not in result.output  # 0008 has not shipped
 
 
 def test_provider_error_exits_4_without_traceback(

--- a/tests/cli/test_registry.py
+++ b/tests/cli/test_registry.py
@@ -34,6 +34,8 @@ from sobres.registry import (
 from sobres.results import MessageResult, Result
 
 EXPECTED_COMMANDS = [
+    "analyze.factors",
+    "analyze.stock",
     "cache.clear",
     "cache.info",
     "commands",

--- a/tests/core/test_factors.py
+++ b/tests/core/test_factors.py
@@ -1,0 +1,183 @@
+"""Factor regressions against closed forms and an independent implementation.
+
+Scenarios: Supported models; Excess returns, not raw; Reported statistics;
+Robust standard errors; Alpha is reported honestly; Minimum sample; Rolling betas.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sobres.core.conventions import PERIODS_PER_YEAR
+from sobres.core.errors import InsufficientDataError, UsageError
+from sobres.core.factors import (
+    ALPHA_NOT_DISTINGUISHABLE,
+    MIN_OBS,
+    MODELS,
+    capm_beta,
+    excess_returns,
+    factor_regression,
+    newey_west_lags,
+    rolling_loadings,
+    to_monthly_returns,
+)
+
+MONTHS = pd.date_range("2015-01-31", periods=144, freq="ME")
+
+
+def _factors(n: int = 60, seed: int = 1) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    frame = pd.DataFrame(
+        {
+            "Mkt-RF": rng.normal(0.006, 0.04, n),
+            "SMB": rng.normal(0.001, 0.02, n),
+            "HML": rng.normal(0.000, 0.02, n),
+            "RMW": rng.normal(0.002, 0.015, n),
+            "CMA": rng.normal(0.001, 0.012, n),
+            "MOM": rng.normal(0.004, 0.03, n),
+            "RF": np.full(n, 0.001),
+        },
+        index=MONTHS[:n],
+    )
+    frame.index.name = "date"
+    return frame
+
+
+def test_supported_models_and_the_columns_each_uses() -> None:
+    assert MODELS == ("capm", "ff3", "ff5", "ff5+mom")
+    f = _factors()
+    r = f["RF"] + 0.001 + 1.2 * f["Mkt-RF"]
+    for model, n_terms in (("capm", 1), ("ff3", 3), ("ff5", 5), ("ff5+mom", 6)):
+        fit = factor_regression(r, f, model)
+        assert list(fit.loadings) == list(f.columns[:n_terms]) and fit.model == model
+    with pytest.raises(UsageError):
+        factor_regression(r, f, "ff7")
+
+
+def test_excess_returns_subtract_the_factor_files_rf_not_a_separate_rate() -> None:
+    f = _factors()
+    r = pd.Series(0.01, index=f.index)
+    ex = excess_returns(r, f)
+    np.testing.assert_allclose(ex.to_numpy(), 0.009)  # 0.01 - RF 0.001
+    with pytest.raises(UsageError):
+        excess_returns(r, f.drop(columns="RF"))
+    # An exact linear relation in excess terms is recovered only if RF was subtracted.
+    exact = f["RF"] + 0.002 + 0.8 * f["Mkt-RF"] - 0.3 * f["SMB"] + 0.5 * f["HML"]
+    fit = factor_regression(exact, f, "ff3")
+    assert fit.alpha.coefficient == pytest.approx(0.002, abs=1e-12)
+    assert fit.loadings["Mkt-RF"].coefficient == pytest.approx(0.8, abs=1e-12)
+    assert fit.loadings["SMB"].coefficient == pytest.approx(-0.3, abs=1e-12)
+    assert fit.loadings["HML"].coefficient == pytest.approx(0.5, abs=1e-12)
+    assert fit.r2 == pytest.approx(1.0, abs=1e-12)
+
+
+def test_reported_statistics_match_the_two_variable_closed_form() -> None:
+    # Five points, one factor: y = a + b x + e. Closed form (any statistics textbook):
+    # b = Sxy/Sxx, a = ȳ - b x̄, s² = Σe²/(n-2), se(b) = s/√Sxx, se(a) = s √(1/n + x̄²/Sxx).
+    x = np.array([-0.02, -0.01, 0.00, 0.01, 0.03])
+    y = np.array([-0.030, -0.005, 0.004, 0.012, 0.040])
+    f = pd.DataFrame({"Mkt-RF": x, "RF": 0.0}, index=MONTHS[:5])
+    r = pd.Series(y, index=MONTHS[:5])
+    sxx = ((x - x.mean()) ** 2).sum()
+    b = ((x - x.mean()) * (y - y.mean())).sum() / sxx
+    a = y.mean() - b * x.mean()
+    e = y - a - b * x
+    s2 = (e**2).sum() / 3
+    fit = factor_regression(r, f, "capm", min_obs=5, hac_lags=0)
+    assert fit.loadings["Mkt-RF"].coefficient == pytest.approx(b)
+    assert fit.alpha.coefficient == pytest.approx(a)
+    assert fit.loadings["Mkt-RF"].se == pytest.approx(np.sqrt(s2 / sxx))
+    assert fit.alpha.se == pytest.approx(np.sqrt(s2 * (1 / 5 + x.mean() ** 2 / sxx)))
+    assert fit.loadings["Mkt-RF"].t == pytest.approx(b / np.sqrt(s2 / sxx))
+    assert fit.r2 == pytest.approx(1 - (e**2).sum() / ((y - y.mean()) ** 2).sum())
+    assert fit.adj_r2 == pytest.approx(1 - (1 - fit.r2) * 4 / 3)
+    assert fit.n_obs == 5 and fit.start == MONTHS[0] and fit.end == MONTHS[4]
+    assert fit.annualized_alpha == pytest.approx((1 + a) ** PERIODS_PER_YEAR["monthly"] - 1)
+    for stats in (fit.alpha, *fit.loadings.values()):
+        assert 0.0 <= stats.p <= 1.0 and 0.0 <= stats.p_hac <= 1.0
+    assert fit.hac_lags == 0 and fit.alpha.se_hac > 0
+
+
+def test_robust_standard_errors_match_statsmodels_newey_west() -> None:
+    sm = pytest.importorskip("statsmodels.api")
+    f = _factors(120)
+    rng = np.random.default_rng(7)
+    noise = np.zeros(120)
+    for t in range(1, 120):  # AR(1) residuals: exactly the case HAC exists for
+        noise[t] = 0.6 * noise[t - 1] + rng.normal(0, 0.02)
+    r = f["RF"] + 0.003 + 1.1 * f["Mkt-RF"] + 0.4 * f["SMB"] + noise
+    fit = factor_regression(r, f, "ff3", hac_lags=4)
+    x = sm.add_constant(f[["Mkt-RF", "SMB", "HML"]].to_numpy())
+    ref = sm.OLS((r - f["RF"]).to_numpy(), x).fit(cov_type="HAC", cov_kwds={"maxlags": 4})
+    assert fit.hac_lags == 4
+    assert fit.alpha.se_hac == pytest.approx(ref.bse[0], rel=1e-9)
+    for i, name in enumerate(("Mkt-RF", "SMB", "HML"), start=1):
+        assert fit.loadings[name].se_hac == pytest.approx(ref.bse[i], rel=1e-9)
+        assert fit.loadings[name].coefficient == pytest.approx(ref.params[i], rel=1e-12)
+    plain = sm.OLS((r - f["RF"]).to_numpy(), x).fit()
+    assert fit.loadings["Mkt-RF"].se == pytest.approx(plain.bse[1], rel=1e-12)
+    assert fit.loadings["Mkt-RF"].se_hac != pytest.approx(
+        fit.loadings["Mkt-RF"].se, rel=1e-3
+    )  # AR(1) residuals: HAC must differ from OLS by more than rounding
+    assert newey_west_lags(120) == int(np.floor(4 * (1.2) ** (2 / 9)))  # the 1994 rule
+    assert factor_regression(r, f, "ff3").hac_lags == newey_west_lags(120)
+
+
+def test_alpha_is_reported_honestly() -> None:
+    f = _factors(120, seed=3)
+    rng = np.random.default_rng(11)
+    faint = f["RF"] + 0.0002 + 1.0 * f["Mkt-RF"] + rng.normal(0, 0.03, 120)
+    fit = factor_regression(faint, f, "capm")
+    assert fit.alpha.p_hac > 0.05 and not fit.alpha_significant
+    assert fit.alpha_statement.startswith(ALPHA_NOT_DISTINGUISHABLE)
+    assert "should not be read on its own" in fit.alpha_statement
+    loud = f["RF"] + 0.02 + 1.0 * f["Mkt-RF"] + rng.normal(0, 0.005, 120)
+    fit = factor_regression(loud, f, "capm")
+    assert fit.alpha.p_hac <= 0.05 and fit.alpha_significant
+    assert "distinguishable from zero" in fit.alpha_statement
+    assert ALPHA_NOT_DISTINGUISHABLE not in fit.alpha_statement
+
+
+def test_minimum_sample_names_available_and_required() -> None:
+    assert MIN_OBS == {"monthly": 36, "daily": 252}
+    f = _factors(35)
+    r = f["RF"] + f["Mkt-RF"]
+    with pytest.raises(InsufficientDataError) as exc:
+        factor_regression(r, f, "capm")
+    assert "35 monthly observations available, 36 required" in str(exc.value)
+    assert exc.value.exit_code == 5
+    days = pd.bdate_range("2024-01-01", periods=100)
+    fd = pd.DataFrame({"Mkt-RF": np.linspace(-0.01, 0.01, 100), "RF": 0.0}, index=days)
+    with pytest.raises(InsufficientDataError, match="100 daily observations available, 252"):
+        factor_regression(pd.Series(fd["Mkt-RF"]), fd, "capm", frequency="daily")
+
+
+def test_rolling_betas_recover_a_loading_that_changes_halfway() -> None:
+    f = _factors(72)
+    beta = np.where(np.arange(72) < 36, 0.5, 1.5)
+    r = f["RF"] + 0.001 + beta * f["Mkt-RF"]
+    frame = rolling_loadings(r, f, "capm", window=36)
+    assert list(frame.columns) == ["alpha", "Mkt-RF"] and len(frame) == 72 - 36 + 1
+    assert frame["Mkt-RF"].iloc[0] == pytest.approx(0.5, abs=1e-10)  # first window: all 0.5
+    assert frame["Mkt-RF"].iloc[-1] == pytest.approx(1.5, abs=1e-10)  # last window: all 1.5
+    assert 0.5 < frame["Mkt-RF"].iloc[18] < 1.5  # the mixed windows show the instability
+    assert frame.attrs == {"model": "capm", "window": 36, "frequency": "monthly"}
+    with pytest.raises(InsufficientDataError):
+        rolling_loadings(r, f, "capm", window=100)
+    with pytest.raises(UsageError):
+        rolling_loadings(r, f, "ff5", window=6)
+
+
+def test_capm_beta_and_monthly_resampling() -> None:
+    f = _factors()
+    r = f["RF"] + 1.3 * f["Mkt-RF"]
+    assert capm_beta(r, f) == pytest.approx(1.3, abs=1e-12)
+    days = pd.bdate_range("2020-01-01", "2020-03-31")
+    prices = pd.Series(np.linspace(100, 130, len(days)), index=days)
+    monthly = to_monthly_returns(prices)
+    jan_last = prices[prices.index.month == 1].iloc[-1]
+    feb_last = prices[prices.index.month == 2].iloc[-1]
+    assert monthly.iloc[0] == pytest.approx(feb_last / jan_last - 1)
+    assert len(monthly) == 2  # February and March; January has no prior month

--- a/tests/data/test_cache.py
+++ b/tests/data/test_cache.py
@@ -52,8 +52,9 @@ def test_hit_avoids_fetch(cache: ObservationCache) -> None:
         "p", "prices_adj_close", ["aapl"], D(2020, 1, 1), D(2020, 1, 31), _fetcher(calls)
     )
     assert second.attrs["cache"]["status"] == "hit" and len(calls) == 1
-    pd.testing.assert_frame_equal(first, second)
-    assert second.attrs["series_meta"] == {"AAPL": {"currency": "USD"}}
+    # Keys are case-insensitive; the frame comes back in the caller's casing.
+    pd.testing.assert_frame_equal(first, second.rename(columns=str.upper))
+    assert second.attrs["series_meta"] == {"aapl": {"currency": "USD"}}
 
 
 def test_subrange_of_cached_range_makes_no_network_call(cache: ObservationCache) -> None:
@@ -149,3 +150,25 @@ def test_fetch_logged_at_debug(cache: ObservationCache, capsys: pytest.CaptureFi
     cache.get("p", "prices_adj_close", ["AAPL"], D(2020, 1, 1), D(2020, 1, 10), _fetcher([]))
     err = capsys.readouterr().err
     assert '"cache.get"' in err and '"status": "miss"' in err and '"elapsed_ms"' in err
+
+
+def test_mixed_case_symbols_round_trip_with_their_casing(cache: ObservationCache) -> None:
+    """Keys are stored upper-cased, but ``Mkt-RF`` must come back as ``Mkt-RF`` with its
+    values — the Ken French provider's columns are mixed case (0007 found them empty)."""
+    calls: list[tuple[list[str], date, date]] = []
+    frame = cache.get(
+        "ken_french",
+        "factors",
+        ["Mkt-RF", "SMB"],
+        date(2024, 1, 1),
+        date(2024, 1, 10),
+        _fetcher(calls),
+    )
+    assert calls[0][0] == ["Mkt-RF", "SMB"]  # the provider is asked in its own casing
+    assert list(frame.columns) == ["Mkt-RF", "SMB"]
+    assert frame["Mkt-RF"].notna().all() and frame["Mkt-RF"].iloc[0] == 1.0
+    assert frame.attrs["series_meta"]["Mkt-RF"] == {"currency": "USD"}
+    again = cache.get(
+        "ken_french", "factors", ["mkt-rf"], date(2024, 1, 1), date(2024, 1, 10), _fetcher(calls)
+    )
+    assert len(calls) == 1 and list(again.columns) == ["mkt-rf"]  # a hit, in the caller's casing

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -20,7 +20,7 @@ Run `python scripts/record_fixtures.py` with network access (and
 
 | Directory | Shape | Source of truth |
 |---|---|---|
-| `yfinance/` | `Ticker.history(auto_adjust=False)` CSV + `meta.json` currency | yfinance 1.7 |
+| `yfinance/` | `Ticker.history(auto_adjust=False)` CSV + `meta.json` currency; `fundamentals.json` holds the `Ticker.info` keys `analyze stock` reads (0007) | yfinance 1.7 |
 | `fred/` | `fred/series/observations?file_type=json` body | FRED API |
 | `ecb/` | `EXR/D.<CCY>.EUR.SP00.A?format=csvdata` body | ECB Data Portal |
 | `ken_french/` | the CSV inside `<file>_CSV.zip` | Ken French Data Library |

--- a/tests/fixtures/yfinance/fundamentals.json
+++ b/tests/fixtures/yfinance/fundamentals.json
@@ -1,0 +1,68 @@
+{
+  "recorded_at": null,
+  "synthesized_at": "2026-09-12T19:30:00+00:00",
+  "provider": "yfinance",
+  "note": "synthesized in the shape of Ticker.info (the keys sobres reads); GLD is an ETF and has none",
+  "tickers": {
+    "AAPL": {
+      "quoteType": "EQUITY",
+      "longName": "Apple Inc.",
+      "sector": "Technology",
+      "marketCap": 3400000000000,
+      "trailingPE": 33.2,
+      "priceToBook": 48.1,
+      "dividendYield": 0.0044,
+      "currency": "USD"
+    },
+    "MSFT": {
+      "quoteType": "EQUITY",
+      "longName": "Microsoft Corporation",
+      "sector": "Technology",
+      "marketCap": 3100000000000,
+      "trailingPE": 35.7,
+      "priceToBook": 11.9,
+      "dividendYield": 0.0072,
+      "currency": "USD"
+    },
+    "NVDA": {
+      "quoteType": "EQUITY",
+      "longName": "NVIDIA Corporation",
+      "sector": "Technology",
+      "marketCap": 3300000000000,
+      "trailingPE": 54.0,
+      "priceToBook": 51.3,
+      "dividendYield": 0.0003,
+      "currency": "USD"
+    },
+    "JNJ": {
+      "quoteType": "EQUITY",
+      "longName": "Johnson & Johnson",
+      "sector": "Healthcare",
+      "marketCap": 380000000000,
+      "trailingPE": 22.4,
+      "priceToBook": 5.3,
+      "dividendYield": 0.031,
+      "currency": "USD"
+    },
+    "XOM": {
+      "quoteType": "EQUITY",
+      "longName": "Exxon Mobil Corporation",
+      "sector": "Energy",
+      "marketCap": 470000000000,
+      "trailingPE": 13.6,
+      "priceToBook": 1.8,
+      "dividendYield": 0.035,
+      "currency": "USD"
+    },
+    "VOD.L": {
+      "quoteType": "EQUITY",
+      "longName": "Vodafone Group Plc",
+      "sector": "Communication Services",
+      "marketCap": 18000000000,
+      "trailingPE": null,
+      "priceToBook": 0.4,
+      "dividendYield": 0.055,
+      "currency": "GBp"
+    }
+  }
+}

--- a/tests/invariants/test_every_command.py
+++ b/tests/invariants/test_every_command.py
@@ -19,6 +19,28 @@ from tests.conftest import SENTINEL_KEY
 # One runnable, offline invocation per command. A new command must add an entry
 # here or ``test_every_command_has_a_sample`` fails.
 SAMPLE_ARGS: dict[str, list[str]] = {
+    "analyze.factors": [
+        "analyze",
+        "factors",
+        "AAPL",
+        "--start",
+        "2015-01-01",
+        "--end",
+        "2024-12-31",
+        "--fill",
+        "drop",
+    ],
+    "analyze.stock": [
+        "analyze",
+        "stock",
+        "AAPL",
+        "--start",
+        "2020-01-01",
+        "--end",
+        "2024-12-31",
+        "--fill",
+        "drop",
+    ],
     "cache.clear": ["cache", "clear", "--yes"],
     "cache.info": ["cache", "info"],
     "commands": ["commands"],


### PR DESCRIPTION
Adds the `sobres analyze` group. `analyze factors` regresses excess returns (`r - RF`, with `RF` from the same Ken French file) on CAPM, FF3, FF5 or FF5+momentum, monthly by default, reporting per term the coefficient, OLS and Newey-West (HAC) standard errors, t-statistics and p-values, the annualized alpha, R² and adjusted R², the observation count and window, and the HAC lag length; when alpha's HAC p-value exceeds 0.05 the output says it is not statistically distinguishable from zero and that the point estimate should not be read alone. `--rolling N` returns loadings per trailing window; `--tickers` (or `--portfolio`) gives a comparison table in the order supplied. `analyze stock` adds the price summary, annualized return and volatility, the 0002 risk panel, CAPM beta and current fundamentals with the note that they are not point-in-time (omitted with a one-line note for ETFs).

## Main and stack synchronization

This candidate merges main `b9792d7` (PR #33) through updated #12, retaining reviewed #8 corrections via #35. Main's opaque case-sensitive cache identifiers and withdrawal semantics replace the older uppercase-key workaround; mixed-case cold/warm regression coverage remains. Stock risk uses the shared dated risk-free series.

Synthetic fundamentals now live under `tests/fixtures/synthetic/yfinance/`, clearly separated from recorded payloads. Main's four provider directories and manifests remain byte-identical. Fixture mode prefers recorded fundamentals and otherwise uses the labelled synthetic corpus; live providers never load it. A simulated recorder regression proves future fundamentals are hashed by the primary manifest. No live recording was made here.

Current 0007/0013 plans are included. Layout migration and R1/R2 acceptance remain pending under #29; the refreshed branch does not establish synthetic vendor truth or completion of every amended scenario.

## Verification

- 905 non-network tests passed locally; four live tests excluded; 95.73% branch coverage.
- Black/isort (100 columns), Ruff lint/format, mypy, actionlint and all 14 strict OpenSpec checks passed.
- OpenAPI/client regenerated; frontend types/build/bundle gate passed.
- See `docs/integration/pr13-main-sync.md` and GitHub Checks for evidence and limitations.

Refs #29, #23, #35. No pending feature PR, release, or deployment was merged or activated.
